### PR TITLE
ci: add binary distribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,62 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: CI Pipeline
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  translation:
+    name: Build Translation SDK binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Taskfile
+        shell: bash
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+
+      - name: Build
+        run: |
+          task translation:compile:all
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: binaries
+          path: bin
+          if-no-files-found: error
+
+  release:
+    name: Release
+    needs:
+      - translation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries
+          path: bin
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: bin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  success:
+    name: Success
+    needs:
+      - release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Success
+        run: echo "::notice Success!"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,14 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+version: '3'
+
+vars:
+  BIN_DIR: '{{ .ROOT_DIR }}/bin'
+
+includes:
+  translation:
+    taskfile: ./translation/Taskfile.yml
+    dir: ./translation
+    vars:
+      BIN_DIR: '{{ .BIN_DIR }}'

--- a/translation/Taskfile.yml
+++ b/translation/Taskfile.yml
@@ -1,0 +1,25 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+version: '3'
+
+tasks:
+  compile:
+    desc: Compile Translation SDK to host platform
+    vars:
+      GOOS: '{{ .GOOS | default OS }}'
+      GOARCH: '{{ .GOARCH | default ARCH }}'
+      BINARY_NAME: '{{ .BINARY_NAME | default "oasft" }}'
+      OUT_BINARY: '{{ .OUT_BINARY | default (printf "%s/%s" .BIN_DIR .BINARY_NAME) }}'
+    cmds:
+      - CGO_ENABLED=0 GOOS={{.GOOS}} GOARCH={{.GOARCH}} BINARY_NAME={{.BINARY_NAME}} go build -ldflags="-s -w -extldflags -static" -o "{{.OUT_BINARY}}" cmd/main.go
+
+  compile:all:
+    desc: Compile Translation SDK binaries for multiple platforms
+    cmds:
+      - for:
+          matrix:
+            OS: ['linux', 'darwin']
+            ARCH: ['amd64', 'arm64']
+        cmd: |
+          GOOS={{.ITEM.OS}} GOARCH={{.ITEM.ARCH}} BINARY_NAME=oasft-{{.ITEM.OS}}-{{.ITEM.ARCH}} BIN_DIR={{.BIN_DIR}} task compile


### PR DESCRIPTION
This PR adds a Taskfile with tasks to generate the binaries for different platforms. It also adds a GH action to trigger a release with the binaries.