### PR TITLE
release: prepare version v0.0.6

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 require (
 	buf.build/gen/go/agntcy/oasf-sdk/grpc/go v1.5.1-20250915083413-97472ce2fb9f.2
 	buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.9-20250915083413-97472ce2fb9f.1
-	github.com/agntcy/oasf-sdk/pkg v0.0.5
+	github.com/agntcy/oasf-sdk/pkg v0.0.6
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	google.golang.org/grpc v1.74.2

--- a/server/go.mod
+++ b/server/go.mod
@@ -5,7 +5,7 @@ go 1.24.4
 require (
 	buf.build/gen/go/agntcy/oasf-sdk/grpc/go v1.5.1-20250915083413-97472ce2fb9f.2
 	buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.9-20250915083413-97472ce2fb9f.1
-	github.com/agntcy/oasf-sdk/pkg v0.0.5
+	github.com/agntcy/oasf-sdk/pkg v0.0.6
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/viper v1.21.0

--- a/versions.yaml
+++ b/versions.yaml
@@ -3,7 +3,7 @@
 
 module-sets:
   oasf-sdk:
-    version: v0.0.5
+    version: v0.0.6
     modules:
       - github.com/agntcy/oasf-sdk/e2e
       - github.com/agntcy/oasf-sdk/pkg


### PR DESCRIPTION
This PR updates the go modules to prepare for the release of v0.0.6.