### PR TITLE
feat: add golangci-lint

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -2,14 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Buf CI
+
 on:
   push:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   delete:
+
 permissions:
   contents: read
   pull-requests: write
+
 jobs:
   buf:
     runs-on: ubuntu-latest

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -5,8 +5,8 @@ name: License check
 
 on:
   pull_request:
-    branches: [ main ]
-    types: [ opened, synchronize, reopened ]
+    branches: [main]
+    types: [opened, synchronize, reopened]
 
 jobs:  
   license:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,31 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Linting
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Taskfile
+        shell: bash
+        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+
+      - name: Lint with golangci-lint
+        run: |
+          task lint:golangci-lint
+
+      - name: Lint with buf
+        run: |
+          task lint:buf

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,65 @@
+version: "2"
+linters:
+  default: all
+  disable:
+    - depguard # Allow all package imports
+    - embeddedstructfieldcheck # Allow embedded fields in any position
+    - err113
+    - exhaustruct # Allow structures with uninitialized fields
+    - funcorder # Allow flexible function ordering within structs
+    - funlen # Allow long functions
+    - godoclint # Allow flexible godoc comment styles
+    - gochecknoglobals # Allow global variables
+    - gochecknoinits # Allow init function
+    - godox # Allow TODOs
+    - inamedparam # Allow unnamed args
+    - ireturn # Allow returning with interfaces
+    - lll # Allow long lines
+    - noinlineerr # Allow inline error handling
+    - nolintlint # Allow nolint
+    - paralleltest # Allow missing t.Parallel() in tests
+    - revive # Allow flexible code style conventions
+    - tagliatelle # Allow json(camel)
+    - testpackage # Allow not having a test package
+    - varnamelen # Allow short var names
+    - wsl # Deprecated
+  settings:
+    cyclop:
+      max-complexity: 15
+    goheader:
+      values:
+        regexp:
+          YEAR: 202[4-5]
+      template: |-
+        Copyright AGNTCY Contributors (https://github.com/agntcy)
+        SPDX-License-Identifier: Apache-2.0
+    gomoddirectives:
+      replace-allow-list: []
+      replace-local: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+        path: types/adapters/record_oasfv.*\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,13 +26,6 @@ linters:
   settings:
     cyclop:
       max-complexity: 15
-    goheader:
-      values:
-        regexp:
-          YEAR: 202[4-5]
-      template: |-
-        Copyright AGNTCY Contributors (https://github.com/agntcy)
-        SPDX-License-Identifier: Apache-2.0
     gomoddirectives:
       replace-allow-list: []
       replace-local: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,11 @@ vars:
   LICENSEI_BIN: "{{ .BIN_DIR }}/licensei-{{.LICENSEI_VERSION}}"
   MULTIMOD_VERSION: "0.17.0"
   MULTIMOD_BIN: "{{ .BIN_DIR }}/multimod-{{.MULTIMOD_VERSION}}"
+  GOLANGCI_LINT_VERSION: "2.6.1"
+  GOLANGCI_LINT_BIN: "{{ .BIN_DIR }}/golangci-lint-{{.GOLANGCI_LINT_VERSION}}"
+
+  GO_MOD_DIR:
+    sh: find . -name go.mod -exec dirname {} \;
 
 includes:
   e2e:
@@ -33,17 +38,6 @@ tasks:
     cmds:
       - "{{.BUFBUILD_BIN}} dep update"
       - "{{.BUFBUILD_BIN}} format --output ./"
-
-  lint:
-    desc: Run linters
-    deps:
-      - task: deps:protoc
-      - task: deps:bufbuild
-    dir: ./proto
-    cmds:
-      - "{{.BUFBUILD_BIN}} dep update"
-      - "{{.BUFBUILD_BIN}} format --diff --exit-code"
-      - "{{.BUFBUILD_BIN}} lint"
 
   compile:
     desc: Compile binary for host platform
@@ -84,6 +78,38 @@ tasks:
     desc: Build image for multiple platforms
     cmds:
       - docker buildx bake
+  
+  ##
+  ## Linting
+  ##
+  lint:golangci-lint:
+    desc: Run golangci-lint
+    deps:
+      - task: deps:golangci-lint
+    vars:
+      FIX: '{{ .FIX | default "false" }}'
+      FIX_FLAG: '{{if eq .FIX "true"}}--fix{{end}}'
+    cmds:
+      - for: { var: GO_MOD_DIR }
+        cmd: |
+          echo "Running golangci-lint in {{.ITEM}}"
+          cd {{.ITEM}}
+          {{.GOLANGCI_LINT_BIN}} run --config {{.ROOT_DIR}}/.golangci.yml {{.FIX_FLAG}}
+
+  lint:buf:
+    desc: Run Buf linters
+    deps:
+      - task: deps:protoc
+      - task: deps:bufbuild
+    dir: ./proto
+    cmds:
+      - "{{.BUFBUILD_BIN}} lint"
+
+  lint:
+    desc: Run all linters
+    deps:
+      - task: lint:buf
+      - task: lint:golangci-lint
 
   ##
   ## Release
@@ -132,9 +158,6 @@ tasks:
     desc: Cache licenses of dependencies
     deps:
       - task: deps:licensei
-    vars:
-      GO_MOD_DIR:
-        sh: find . -name go.mod -exec dirname {} \;
     cmds:
       - for: { var: GO_MOD_DIR }
         cmd: echo "Caching licenses in {{.ITEM}}" && cd {{.ITEM}} && {{ .LICENSEI_BIN }} cache --config {{.ROOT_DIR}}/.licensei.toml
@@ -144,9 +167,6 @@ tasks:
   ##
   deps:tidy:
     desc: Ensure dependencies are up-to-date
-    vars:
-      GO_MOD_DIR:
-        sh: find . -name go.mod -exec dirname {} \;
     cmds:
       - for: { var: GO_MOD_DIR }
         cmd: go -C {{.ITEM}} mod tidy -go={{.GO_VERSION}}
@@ -228,3 +248,15 @@ tasks:
       - rm -rf {{.MULTIMOD_REPO_DIR}}
     status:
       - test -x {{.MULTIMOD_BIN}}
+
+  deps:golangci-lint:
+    desc: Install golangci-lint
+    internal: true
+    deps:
+      - deps:bin-dir
+    cmds:
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s v{{.GOLANGCI_LINT_VERSION}}
+      - mv {{.BIN_DIR}}/golangci-lint {{.GOLANGCI_LINT_BIN}}
+      - chmod +x {{.GOLANGCI_LINT_BIN}}
+    status:
+      - test -x {{.GOLANGCI_LINT_BIN}}

--- a/e2e/Taskfile.yaml
+++ b/e2e/Taskfile.yaml
@@ -13,7 +13,6 @@ vars:
   HELM_BIN: "{{ .BIN_DIR }}/helm-{{.HELM_VERSION}}"
 
 tasks:
-
   ##
   ## Tests
   ##

--- a/e2e/decoding_test.go
+++ b/e2e/decoding_test.go
@@ -51,12 +51,12 @@ var _ = Describe("Decoding Service E2E", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to marshal decoded record to JSON")
 
 			// Parse expected output
-			var expectedRecord map[string]interface{}
+			var expectedRecord map[string]any
 			err = json.Unmarshal(expectedV031Decoded, &expectedRecord)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected decoded output")
 
 			// Parse actual output for comparison
-			var actualRecord map[string]interface{}
+			var actualRecord map[string]any
 			err = json.Unmarshal(actualJSON, &actualRecord)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual decoded output")
 
@@ -102,12 +102,12 @@ var _ = Describe("Decoding Service E2E", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to marshal decoded record to JSON")
 
 			// Parse expected output
-			var expectedOutput map[string]interface{}
+			var expectedOutput map[string]any
 			err = json.Unmarshal(expectedV080Decoded, &expectedOutput)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected output")
 
 			// Parse actual output
-			var actualOutput map[string]interface{}
+			var actualOutput map[string]any
 			err = json.Unmarshal(actualJSON, &actualOutput)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual output")
 
@@ -143,12 +143,12 @@ var _ = Describe("Decoding Service E2E", func() {
 			Expect(err).NotTo(HaveOccurred(), "Failed to marshal decoded record to JSON")
 
 			// Parse expected output
-			var expectedRecord map[string]interface{}
+			var expectedRecord map[string]any
 			err = json.Unmarshal(expectedV070Decoded, &expectedRecord)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected decoded output")
 
 			// Parse actual output for comparison
-			var actualRecord map[string]interface{}
+			var actualRecord map[string]any
 			err = json.Unmarshal(actualJSON, &actualRecord)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual decoded output")
 
@@ -172,7 +172,7 @@ var _ = Describe("Decoding Service E2E", func() {
 			defer cancel()
 
 			// Create a record without schema_version field
-			recordWithoutSchema := map[string]interface{}{
+			recordWithoutSchema := map[string]any{
 				"authors":     []string{"Test Author"},
 				"created_at":  "2025-09-11T12:00:00Z",
 				"description": "Record without schema version",
@@ -196,7 +196,7 @@ var _ = Describe("Decoding Service E2E", func() {
 			defer cancel()
 
 			// Create a record with unsupported schema version
-			recordWithUnsupportedSchema := map[string]interface{}{
+			recordWithUnsupportedSchema := map[string]any{
 				"authors":        []string{"Test Author"},
 				"created_at":     "2025-09-11T12:00:00Z",
 				"description":    "Record with unsupported schema",

--- a/e2e/translation_test.go
+++ b/e2e/translation_test.go
@@ -24,35 +24,33 @@ var _ = Describe("Translation Service E2E", func() {
 
 	client := translationv1grpc.NewTranslationServiceClient(conn)
 
-	Context("GH Copilot config Generation", func() {
-		It("should generate github GH Copilot config from 0.8.0 record matching expected output", func() {
+	Context("GH Copilot config Generation", func() { //nolint:dupl
+		It("should generate github GH Copilot config from 0.8.0 record matching expected output", func() { //nolint:dupl
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			encodedRecord, err := decoder.JsonToProto(translationV080Record)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal translation record")
 
-			req := &translationv1.RecordToGHCopilotRequest{
-				Record: encodedRecord,
-			}
+			req := &translationv1.RecordToGHCopilotRequest{Record: encodedRecord}
 
 			resp, err := client.RecordToGHCopilot(ctx, req)
 			Expect(err).NotTo(HaveOccurred(), "RecordToGHCopilot should not fail")
-			Expect(resp.Data).NotTo(BeNil(), "Expected GH Copilot config data in response")
+			Expect(resp.GetData()).NotTo(BeNil(), "Expected GH Copilot config data in response")
 
 			// Convert response to JSON for comparison
-			actualJSON, err := json.MarshalIndent(resp.Data.AsMap(), "", "  ")
-			Expect(err).NotTo(HaveOccurred(), "Failed to marshal GH Copilot config to JSON")
+			actualJSON, err := json.MarshalIndent(resp.GetData().AsMap(), "", "  ")
+			Expect(err).NotTo(HaveOccurred(), "Failed to marshal response to JSON")
 
 			// Parse expected output
-			var expectedOutput map[string]interface{}
+			var expectedOutput map[string]any
 			err = json.Unmarshal(expectedGHCopilotOutput, &expectedOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected GH Copilot output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected output")
 
 			// Parse actual output for comparison
-			var actualOutput map[string]interface{}
+			var actualOutput map[string]any
 			err = json.Unmarshal(actualJSON, &actualOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual GH Copilot output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual output")
 
 			// Compare structure against expected output
 			Expect(actualOutput).To(Equal(expectedOutput), "GH Copilot config should match expected output")
@@ -71,43 +69,41 @@ var _ = Describe("Translation Service E2E", func() {
 
 			resp, err := client.RecordToGHCopilot(ctx, req)
 			Expect(err).NotTo(HaveOccurred(), "RecordToGHCopilot should not fail for 0.7.0 record")
-			Expect(resp.Data).NotTo(BeNil(), "Expected GH Copilot config data in response")
+			Expect(resp.GetData()).NotTo(BeNil(), "Expected GH Copilot config data in response")
 
 			// Verify we got valid MCP config structure
-			mcpConfig := resp.Data.AsMap()["mcpConfig"]
+			mcpConfig := resp.GetData().AsMap()["mcpConfig"]
 			Expect(mcpConfig).NotTo(BeNil(), "Expected mcpConfig in response")
 		})
 	})
 
-	Context("A2A Card Extraction", func() {
-		It("should extract A2A card from 0.8.0 record matching expected output", func() {
+	Context("A2A Card Extraction", func() { //nolint:dupl
+		It("should extract A2A card from 0.8.0 record matching expected output", func() { //nolint:dupl
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			encodedRecord, err := decoder.JsonToProto(translationV080Record)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal translation record")
 
-			req := &translationv1.RecordToA2ARequest{
-				Record: encodedRecord,
-			}
+			req := &translationv1.RecordToA2ARequest{Record: encodedRecord}
 
 			resp, err := client.RecordToA2A(ctx, req)
 			Expect(err).NotTo(HaveOccurred(), "RecordToA2A should not fail")
-			Expect(resp.Data).NotTo(BeNil(), "Expected A2A card data in response")
+			Expect(resp.GetData()).NotTo(BeNil(), "Expected A2A card data in response")
 
 			// Convert response to JSON for comparison
-			actualJSON, err := json.MarshalIndent(resp.Data.AsMap(), "", "  ")
-			Expect(err).NotTo(HaveOccurred(), "Failed to marshal A2A card to JSON")
+			actualJSON, err := json.MarshalIndent(resp.GetData().AsMap(), "", "  ")
+			Expect(err).NotTo(HaveOccurred(), "Failed to marshal response to JSON")
 
 			// Parse expected output
-			var expectedOutput map[string]interface{}
+			var expectedOutput map[string]any
 			err = json.Unmarshal(expectedA2AOutput, &expectedOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected A2A output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected output")
 
 			// Parse actual output for comparison
-			var actualOutput map[string]interface{}
+			var actualOutput map[string]any
 			err = json.Unmarshal(actualJSON, &actualOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual A2A output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual output")
 
 			// Compare structure against expected output
 			Expect(actualOutput).To(Equal(expectedOutput), "A2A card should match expected output")
@@ -120,22 +116,20 @@ var _ = Describe("Translation Service E2E", func() {
 			encodedRecord, err := decoder.JsonToProto(translationV070Record)
 			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal translation record")
 
-			req := &translationv1.RecordToA2ARequest{
-				Record: encodedRecord,
-			}
+			req := &translationv1.RecordToA2ARequest{Record: encodedRecord}
 
 			resp, err := client.RecordToA2A(ctx, req)
 			Expect(err).NotTo(HaveOccurred(), "RecordToA2A should not fail for 0.7.0 record")
-			Expect(resp.Data).NotTo(BeNil(), "Expected A2A card data in response")
+			Expect(resp.GetData()).NotTo(BeNil(), "Expected A2A card data in response")
 
-			// Verify we got valid A2A card structure
-			a2aCard := resp.Data.AsMap()["a2aCard"]
+			// Verify we got valid A2A structure
+			a2aCard := resp.GetData().AsMap()["a2aCard"]
 			Expect(a2aCard).NotTo(BeNil(), "Expected a2aCard in response")
 		})
 	})
 
 	Context("A2A to Record Translation", func() {
-		It("should convert A2A card to OASF record matching expected output", func() {
+		It("should convert A2A card to OASF record matching expected output", func() { //nolint:dupl
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
@@ -148,21 +142,21 @@ var _ = Describe("Translation Service E2E", func() {
 
 			resp, err := client.A2AToRecord(ctx, req)
 			Expect(err).NotTo(HaveOccurred(), "A2AToRecord should not fail")
-			Expect(resp.Record).NotTo(BeNil(), "Expected OASF record in response")
+			Expect(resp.GetRecord()).NotTo(BeNil(), "Expected OASF record in response")
 
 			// Convert response to JSON for comparison
-			actualJSON, err := json.MarshalIndent(resp.Record.AsMap(), "", "  ")
-			Expect(err).NotTo(HaveOccurred(), "Failed to marshal record to JSON")
+			actualJSON, err := json.MarshalIndent(resp.GetRecord().AsMap(), "", "  ")
+			Expect(err).NotTo(HaveOccurred(), "Failed to marshal response to JSON")
 
 			// Parse expected output
-			var expectedOutput map[string]interface{}
+			var expectedOutput map[string]any
 			err = json.Unmarshal(expectedA2AToRecordOutput, &expectedOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected A2AToRecord output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected output")
 
 			// Parse actual output for comparison
-			var actualOutput map[string]interface{}
+			var actualOutput map[string]any
 			err = json.Unmarshal(actualJSON, &actualOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual A2AToRecord output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual output")
 
 			// Compare structure against expected output
 			Expect(actualOutput).To(Equal(expectedOutput), "OASF record should match expected output")
@@ -170,7 +164,7 @@ var _ = Describe("Translation Service E2E", func() {
 	})
 
 	Context("MCP to Record Translation", func() {
-		It("should convert MCP Registry entry to OASF record matching expected output", func() {
+		It("should convert MCP Registry entry to OASF record matching expected output", func() { //nolint:dupl
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
@@ -183,27 +177,27 @@ var _ = Describe("Translation Service E2E", func() {
 
 			resp, err := client.MCPToRecord(ctx, req)
 			Expect(err).NotTo(HaveOccurred(), "MCPToRecord should not fail")
-			Expect(resp.Record).NotTo(BeNil(), "Expected OASF record in response")
+			Expect(resp.GetRecord()).NotTo(BeNil(), "Expected OASF record in response")
 
 			// Convert response to JSON for comparison
-			actualJSON, err := json.MarshalIndent(resp.Record.AsMap(), "", "  ")
-			Expect(err).NotTo(HaveOccurred(), "Failed to marshal record to JSON")
+			actualJSON, err := json.MarshalIndent(resp.GetRecord().AsMap(), "", "  ")
+			Expect(err).NotTo(HaveOccurred(), "Failed to marshal response to JSON")
 
 			// Parse expected output
-			var expectedOutput map[string]interface{}
+			var expectedOutput map[string]any
 			err = json.Unmarshal(expectedMCPToRecordOutput, &expectedOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected MCPToRecord output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected output")
 
 			// Parse actual output for comparison
-			var actualOutput map[string]interface{}
+			var actualOutput map[string]any
 			err = json.Unmarshal(actualJSON, &actualOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual MCPToRecord output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual output")
 
 			// Compare structure against expected output
 			Expect(actualOutput).To(Equal(expectedOutput), "OASF record should match expected output")
 		})
 
-		It("should convert minimal local MCP server (pypi, no runtimeHint) to OASF record", func() {
+		It("should convert minimal local MCP server (pypi, no runtimeHint) to OASF record", func() { //nolint:dupl
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
@@ -216,57 +210,65 @@ var _ = Describe("Translation Service E2E", func() {
 
 			resp, err := client.MCPToRecord(ctx, req)
 			Expect(err).NotTo(HaveOccurred(), "MCPToRecord should not fail for minimal local")
-			Expect(resp.Record).NotTo(BeNil(), "Expected OASF record in response")
+			Expect(resp.GetRecord()).NotTo(BeNil(), "Expected OASF record in response")
 
-			actualJSON, err := json.MarshalIndent(resp.Record.AsMap(), "", "  ")
-			Expect(err).NotTo(HaveOccurred(), "Failed to marshal record to JSON")
+			// Convert response to JSON for comparison
+			actualJSON, err := json.MarshalIndent(resp.GetRecord().AsMap(), "", "  ")
+			Expect(err).NotTo(HaveOccurred(), "Failed to marshal response to JSON")
 
-			var expectedOutput map[string]interface{}
+			// Parse expected output
+			var expectedOutput map[string]any
 			err = json.Unmarshal(expectedMCPMinimalLocalOutput, &expectedOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected minimal local output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected output")
 
-			var actualOutput map[string]interface{}
+			// Parse actual output for comparison
+			var actualOutput map[string]any
 			err = json.Unmarshal(actualJSON, &actualOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual minimal local output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual output")
 
+			// Compare structure against expected output
 			Expect(actualOutput).To(Equal(expectedOutput), "Minimal local OASF record should match expected output")
 		})
 
-		It("should convert HTTP remote MCP server with headers to OASF record", func() {
+		It("should convert HTTP remote MCP server with headers to OASF record", func() { //nolint:dupl
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			encodedMCPData, err := decoder.JsonToProto(translationMCPHTTPHeaders)
-			Expect(err).NotTo(HaveOccurred(), "Failed to encode HTTP headers MCP data")
+			Expect(err).NotTo(HaveOccurred(), "Failed to encode MCP HTTP headers data")
 
 			req := &translationv1.MCPToRecordRequest{
 				Data: encodedMCPData,
 			}
 
 			resp, err := client.MCPToRecord(ctx, req)
-			Expect(err).NotTo(HaveOccurred(), "MCPToRecord should not fail for HTTP with headers")
-			Expect(resp.Record).NotTo(BeNil(), "Expected OASF record in response")
+			Expect(err).NotTo(HaveOccurred(), "MCPToRecord should not fail for HTTP headers")
+			Expect(resp.GetRecord()).NotTo(BeNil(), "Expected OASF record in response")
 
-			actualJSON, err := json.MarshalIndent(resp.Record.AsMap(), "", "  ")
-			Expect(err).NotTo(HaveOccurred(), "Failed to marshal record to JSON")
+			// Convert response to JSON for comparison
+			actualJSON, err := json.MarshalIndent(resp.GetRecord().AsMap(), "", "  ")
+			Expect(err).NotTo(HaveOccurred(), "Failed to marshal response to JSON")
 
-			var expectedOutput map[string]interface{}
+			// Parse expected output
+			var expectedOutput map[string]any
 			err = json.Unmarshal(expectedMCPHTTPHeadersOutput, &expectedOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected HTTP headers output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected output")
 
-			var actualOutput map[string]interface{}
+			// Parse actual output for comparison
+			var actualOutput map[string]any
 			err = json.Unmarshal(actualJSON, &actualOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual HTTP headers output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual output")
 
+			// Compare structure against expected output
 			Expect(actualOutput).To(Equal(expectedOutput), "HTTP headers OASF record should match expected output")
 		})
 
-		It("should convert minimal SSE remote MCP server to OASF record", func() {
+		It("should convert SSE minimal MCP server to OASF record", func() { //nolint:dupl
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			encodedMCPData, err := decoder.JsonToProto(translationMCPSSEMinimal)
-			Expect(err).NotTo(HaveOccurred(), "Failed to encode SSE minimal MCP data")
+			Expect(err).NotTo(HaveOccurred(), "Failed to encode MCP SSE minimal data")
 
 			req := &translationv1.MCPToRecordRequest{
 				Data: encodedMCPData,
@@ -274,19 +276,23 @@ var _ = Describe("Translation Service E2E", func() {
 
 			resp, err := client.MCPToRecord(ctx, req)
 			Expect(err).NotTo(HaveOccurred(), "MCPToRecord should not fail for SSE minimal")
-			Expect(resp.Record).NotTo(BeNil(), "Expected OASF record in response")
+			Expect(resp.GetRecord()).NotTo(BeNil(), "Expected OASF record in response")
 
-			actualJSON, err := json.MarshalIndent(resp.Record.AsMap(), "", "  ")
-			Expect(err).NotTo(HaveOccurred(), "Failed to marshal record to JSON")
+			// Convert response to JSON for comparison
+			actualJSON, err := json.MarshalIndent(resp.GetRecord().AsMap(), "", "  ")
+			Expect(err).NotTo(HaveOccurred(), "Failed to marshal response to JSON")
 
-			var expectedOutput map[string]interface{}
+			// Parse expected output
+			var expectedOutput map[string]any
 			err = json.Unmarshal(expectedMCPSSEMinimalOutput, &expectedOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected SSE minimal output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal expected output")
 
-			var actualOutput map[string]interface{}
+			// Parse actual output for comparison
+			var actualOutput map[string]any
 			err = json.Unmarshal(actualJSON, &actualOutput)
-			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual SSE minimal output")
+			Expect(err).NotTo(HaveOccurred(), "Failed to unmarshal actual output")
 
+			// Compare structure against expected output
 			Expect(actualOutput).To(Equal(expectedOutput), "SSE minimal OASF record should match expected output")
 		})
 	})

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -93,11 +93,11 @@ var _ = Describe("Validation Service E2E", func() {
 
 				Expect(err).NotTo(HaveOccurred(), "ValidateRecord should not fail", err)
 				if tc.shouldPass {
-					Expect(resp.IsValid).To(BeTrue(), "Expected valid record", resp.Errors)
-					Expect(resp.Errors).To(BeEmpty(), "Expected no validation errors", resp.Errors)
+					Expect(resp.GetIsValid()).To(BeTrue(), "Expected valid record", resp.GetErrors())
+					Expect(resp.GetErrors()).To(BeEmpty(), "Expected no validation errors", resp.GetErrors())
 				} else {
-					Expect(resp.IsValid).To(BeFalse(), "Expected invalid record", resp.Errors)
-					Expect(resp.Errors).NotTo(BeEmpty(), "Expected validation errors", resp.Errors)
+					Expect(resp.GetIsValid()).To(BeFalse(), "Expected invalid record", resp.GetErrors())
+					Expect(resp.GetErrors()).NotTo(BeEmpty(), "Expected validation errors", resp.GetErrors())
 				}
 			})
 		})

--- a/pkg/decoder/object.go
+++ b/pkg/decoder/object.go
@@ -5,6 +5,7 @@ package decoder
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -13,7 +14,7 @@ import (
 func JsonToProto(data []byte) (*structpb.Struct, error) {
 	var result *structpb.Struct
 	if err := json.Unmarshal(data, &result); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal JSON to protobuf struct: %w", err)
 	}
 
 	return result, nil
@@ -23,7 +24,7 @@ func JsonToProto(data []byte) (*structpb.Struct, error) {
 func StructToProto(goObj any) (*structpb.Struct, error) {
 	jsonBytes, err := json.Marshal(goObj)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal Go struct to JSON: %w", err)
 	}
 
 	return JsonToProto(jsonBytes)
@@ -34,13 +35,13 @@ func ProtoToStruct[T any](obj *structpb.Struct) (*T, error) {
 	// Convert protobuf Struct to JSON
 	jsonBytes, err := json.Marshal(obj)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal protobuf struct to JSON: %w", err)
 	}
 
 	// Unmarshal JSON to the target Go type
 	var result T
 	if err := json.Unmarshal(jsonBytes, &result); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshal JSON to Go struct: %w", err)
 	}
 
 	return &result, nil

--- a/server/controller/translation/v1/translation.go
+++ b/server/controller/translation/v1/translation.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+
 	"buf.build/gen/go/agntcy/oasf-sdk/grpc/go/agntcy/oasfsdk/translation/v1/translationv1grpc"
 	translationv1 "buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go/agntcy/oasfsdk/translation/v1"
 	"github.com/agntcy/oasf-sdk/pkg/decoder"

--- a/server/server.go
+++ b/server/server.go
@@ -34,7 +34,7 @@ func Run(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("failed to create server: %w", err)
 	}
 
-	if err := server.start(); err != nil {
+	if err := server.start(ctx); err != nil {
 		return fmt.Errorf("failed to start server: %w", err)
 	}
 	defer server.close()
@@ -76,8 +76,10 @@ func (s Server) close() {
 	s.grpcServer.GracefulStop()
 }
 
-func (s Server) start() error {
-	listen, err := net.Listen("tcp", s.cfg.ListenAddress)
+func (s Server) start(ctx context.Context) error {
+	lc := &net.ListenConfig{}
+
+	listen, err := lc.Listen(ctx, "tcp", s.cfg.ListenAddress)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", s.cfg.ListenAddress, err)
 	}


### PR DESCRIPTION
This PR adds `golangci-lint` to the repo, adds taskfile task for it and also calls it in the CI.
It also adds `buf lint` linter to the repo.