### PR TITLE
feat: add warnings to ValidateRecord proto messages

### DIFF
--- a/proto/agntcy/oasfsdk/validation/v1/validation_service.proto
+++ b/proto/agntcy/oasfsdk/validation/v1/validation_service.proto
@@ -33,6 +33,9 @@ message ValidateRecordResponse {
 
   // A list of validation errors, if any.
   repeated string errors = 2;
+
+  // A list of validation warnings, if any.
+  repeated string warnings = 3;
 }
 
 message ValidateRecordStreamRequest {
@@ -51,4 +54,7 @@ message ValidateRecordStreamResponse {
 
   // A list of validation errors, if any.
   repeated string errors = 2;
+
+  // A list of validation warnings, if any.
+  repeated string warnings = 3;
 }


### PR DESCRIPTION
Added `warnings` field to the ValidateRecord response proto messages, so it reflects the response from the OASF API and makes it easier to collect errors and warnings separately.

Relates to #115 