### PR TITLE
feat: schema package to return structured taxonomy

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -182,7 +182,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 
@@ -224,32 +223,22 @@ func main() {
 	}
 	fmt.Printf("Schema version 0.8.0 loaded successfully\n")
 
-	// Get skills from schema (using default version - no option needed)
+	// Get nested skill categories (using default version - no option needed)
 	skillsData, err := s.GetSchemaSkills(ctx)
 	if err != nil {
 		log.Fatalf("Failed to get skills: %v", err)
 	}
+	fmt.Printf("Found %d top-level skill categories\n", len(skillsData))
 
-	var skillsMap map[string]interface{}
-	if err := json.Unmarshal(skillsData, &skillsMap); err != nil {
-		log.Fatalf("Failed to parse skills: %v", err)
-	}
-	fmt.Printf("Found %d skills in schema\n", len(skillsMap))
-
-	// Get domains from schema (using specific version)
+	// Get nested domain categories (using specific version)
 	domainsData, err := s.GetSchemaDomains(ctx, schema.WithVersion("0.8.0"))
 	if err != nil {
 		log.Fatalf("Failed to get domains: %v", err)
 	}
+	fmt.Printf("Found %d top-level domain categories\n", len(domainsData))
 
-	var domainsMap map[string]interface{}
-	if err := json.Unmarshal(domainsData, &domainsMap); err != nil {
-		log.Fatalf("Failed to parse domains: %v", err)
-	}
-	fmt.Printf("Found %d domains in schema\n", len(domainsMap))
-
-	// Get a specific $defs key (e.g., modules) using default version
-	modulesData, err := s.GetSchemaKey(ctx, "modules")
+	// Get nested module categories (using default version)
+	modulesData, err := s.GetSchemaModules(ctx)
 	if err != nil {
 		log.Fatalf("Failed to get modules: %v", err)
 	}
@@ -325,23 +314,11 @@ schemaContent, err := s.GetRecordSchemaContent(ctx)
 schemaContent, err := s.GetRecordSchemaContent(ctx, schema.WithVersion("0.8.0"))
 ```
 
-### GetSchemaKey
-Extracts a specific `$defs` category from the schema. If no version is provided, the default version is used:
-```go
-// Using default version
-skillsData, err := s.GetSchemaKey(ctx, "skills")
-
-// Using specific version
-skillsData, err := s.GetSchemaKey(ctx, "skills", schema.WithVersion("0.8.0"))
-domainsData, err := s.GetSchemaKey(ctx, "domains", schema.WithVersion("0.8.0"))
-modulesData, err := s.GetSchemaKey(ctx, "modules", schema.WithVersion("0.8.0"))
-```
-
 ### Convenience Methods
-All convenience methods accept optional `WithVersion()` option. If omitted, the default version is used:
-- `GetSchemaSkills(ctx, ...SchemaOption)` - Extracts skills definitions
-- `GetSchemaDomains(ctx, ...SchemaOption)` - Extracts domains definitions
-- `GetSchemaModules(ctx, ...SchemaOption)` - Extracts modules definitions
+All convenience methods accept optional `WithVersion()` option. If omitted, the default version is used. These methods call the new taxonomy endpoints and return nested Go structs (`schema.SchemaCategories`):
+- `GetSchemaSkills(ctx, ...SchemaOption)` - calls `/api/<version>/skill_categories`
+- `GetSchemaDomains(ctx, ...SchemaOption)` - calls `/api/<version>/domain_categories`
+- `GetSchemaModules(ctx, ...SchemaOption)` - calls `/api/<version>/module_categories`
 
 ### Accessing Agent Skills data from a record
 The translator package can render a spec-compliant `SKILL.md` directly from a record.

--- a/USAGE.md
+++ b/USAGE.md
@@ -189,11 +189,18 @@ import (
 )
 
 func main() {
-	// Create a new schema instance with schema URL
+	// Create a new schema instance with schema URL (cache disabled by default)
 	s, err := schema.New("https://schema.oasf.outshift.com")
 	if err != nil {
 		log.Fatalf("Failed to create schema instance: %v", err)
 	}
+
+	// Optional: enable dynamic cache (only requested data is cached)
+	cachedClient, err := schema.New("https://schema.oasf.outshift.com", schema.WithCache(true))
+	if err != nil {
+		log.Fatalf("Failed to create cached schema instance: %v", err)
+	}
+	_ = cachedClient
 
 	ctx := context.Background()
 
@@ -205,23 +212,19 @@ func main() {
 	fmt.Printf("Available schema versions: %v\n", versions)
 
 	// Get the default schema version (cached after first fetch)
-	defaultVersion, err := s.GetDefaultVersion(ctx)
+	defaultVersion, err := s.GetDefaultSchemaVersion(ctx)
 	if err != nil {
 		log.Fatalf("Failed to get default version: %v", err)
 	}
 	fmt.Printf("Default schema version: %s\n", defaultVersion)
 
-	// Get full schema content for version 0.8.0 (using WithVersion option)
-	schemaContent, err := s.GetRecordSchemaContent(ctx, schema.WithVersion("0.8.0"))
+	// Get full schema content for version 0.8.0 (using WithSchemaVersion option)
+	schemaContent, err := s.GetRecordJSONSchema(ctx, schema.WithSchemaVersion("0.8.0"))
 	if err != nil {
 		log.Fatalf("Failed to get schema content: %v", err)
 	}
 
-	var schemaMap map[string]interface{}
-	if err := json.Unmarshal(schemaContent, &schemaMap); err != nil {
-		log.Fatalf("Failed to parse schema: %v", err)
-	}
-	fmt.Printf("Schema version 0.8.0 loaded successfully\n")
+	fmt.Printf("Schema version 0.8.0 loaded successfully (%d bytes)\n", len(schemaContent))
 
 	// Get nested skill categories (using default version - no option needed)
 	skillsData, err := s.GetSchemaSkills(ctx)
@@ -231,7 +234,7 @@ func main() {
 	fmt.Printf("Found %d top-level skill categories\n", len(skillsData))
 
 	// Get nested domain categories (using specific version)
-	domainsData, err := s.GetSchemaDomains(ctx, schema.WithVersion("0.8.0"))
+	domainsData, err := s.GetSchemaDomains(ctx, schema.WithSchemaVersion("0.8.0"))
 	if err != nil {
 		log.Fatalf("Failed to get domains: %v", err)
 	}
@@ -242,36 +245,20 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to get modules: %v", err)
 	}
+	fmt.Printf("Found %d top-level module categories\n", len(modulesData))
 
-	var modulesMap map[string]interface{}
-	if err := json.Unmarshal(modulesData, &modulesMap); err != nil {
-		log.Fatalf("Failed to parse modules: %v", err)
+	// Get a specific JSON schema by type and name (using WithSchemaVersion option)
+	agentSkillsSchema, err := s.GetJSONSchema(ctx, schema.EntityTypeModules, "agentskills", schema.WithSchemaVersion("1.0.0"))
+	if err != nil {
+		log.Fatalf("Failed to get agent skills module schema: %v", err)
 	}
-  fmt.Printf("Found %d modules in schema\n", len(modulesMap))
+	fmt.Printf("Agent skills module schema loaded (%d bytes)\n", len(agentSkillsSchema))
 
-  // Get the Agent Skills module schema (includes the data field)
-  agentSkillsSchema, err := s.GetSchema(ctx, schema.SchemaTypeModules, "agentskills", schema.WithVersion("1.0.0"))
-  if err != nil {
-    log.Fatalf("Failed to get agent skills module schema: %v", err)
-  }
-
-  var agentSkillsMap map[string]interface{}
-  if err := json.Unmarshal(agentSkillsSchema, &agentSkillsMap); err != nil {
-    log.Fatalf("Failed to parse agent skills module schema: %v", err)
-  }
-  fmt.Printf("Agent skills module schema loaded\n")
-
-  // Get the Agent Skills manifest object schema
-  agentSkillsManifestSchema, err := s.GetSchema(ctx, schema.SchemaTypeObjects, "agentskills_manifest", schema.WithVersion("1.0.0"))
-  if err != nil {
-    log.Fatalf("Failed to get agent skills manifest schema: %v", err)
-  }
-
-  var agentSkillsManifestMap map[string]interface{}
-  if err := json.Unmarshal(agentSkillsManifestSchema, &agentSkillsManifestMap); err != nil {
-    log.Fatalf("Failed to parse agent skills manifest schema: %v", err)
-  }
-  fmt.Printf("Agent skills manifest schema loaded\n")
+	agentSkillsManifestSchema, err := s.GetJSONSchema(ctx, schema.EntityTypeObjects, "agentskills_manifest", schema.WithSchemaVersion("1.0.0"))
+	if err != nil {
+		log.Fatalf("Failed to get agent skills manifest schema: %v", err)
+	}
+	fmt.Printf("Agent skills manifest schema loaded (%d bytes)\n", len(agentSkillsManifestSchema))
 }
 ```
 
@@ -298,24 +285,30 @@ if err != nil {
 
 ## API Methods
 
-### GetDefaultVersion
+### GetDefaultSchemaVersion
 Returns the default schema version from the server. The version is cached after the first fetch:
 ```go
-defaultVersion, err := s.GetDefaultVersion(ctx)
+defaultVersion, err := s.GetDefaultSchemaVersion(ctx)
 ```
 
-### GetRecordSchemaContent
-Fetches the complete JSON schema. If no version is provided via `WithVersion()`, the default version from the server is used:
+### Cache behavior
+- Caching is disabled by default.
+- Enable dynamic caching via constructor option: `schema.New(url, schema.WithCache(true))`.
+- Dynamic caching stores only data that has been requested.
+- Clear in-memory cache with `s.ClearCache()`.
+
+### GetRecordJSONSchema
+Fetches the complete JSON schema. If no version is provided via `WithSchemaVersion()`, the default version from the server is used:
 ```go
 // Using default version
-schemaContent, err := s.GetRecordSchemaContent(ctx)
+schemaContent, err := s.GetRecordJSONSchema(ctx)
 
 // Using specific version
-schemaContent, err := s.GetRecordSchemaContent(ctx, schema.WithVersion("0.8.0"))
+schemaContent, err := s.GetRecordJSONSchema(ctx, schema.WithSchemaVersion("0.8.0"))
 ```
 
 ### Convenience Methods
-All convenience methods accept optional `WithVersion()` option. If omitted, the default version is used. These methods call the new taxonomy endpoints and return nested Go structs (`schema.SchemaCategories`):
+All convenience methods accept optional `WithSchemaVersion()` option. If omitted, the default version is used. These methods call the new taxonomy endpoints and return nested Go structs (`schema.Taxonomy`):
 - `GetSchemaSkills(ctx, ...SchemaOption)` - calls `/api/<version>/skill_categories`
 - `GetSchemaDomains(ctx, ...SchemaOption)` - calls `/api/<version>/domain_categories`
 - `GetSchemaModules(ctx, ...SchemaOption)` - calls `/api/<version>/module_categories`
@@ -336,7 +329,7 @@ Example:
 skills, err := s.GetSchemaSkills(ctx)
 
 // Using specific version
-skills, err := s.GetSchemaSkills(ctx, schema.WithVersion("0.7.0"))
+skills, err := s.GetSchemaSkills(ctx, schema.WithSchemaVersion("0.7.0"))
 ```
 
 # Validation Service

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -9,3 +9,5 @@ require (
 )
 
 require github.com/Masterminds/semver/v3 v3.4.0
+
+require golang.org/x/sync v0.14.0

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -6,5 +6,9 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -33,6 +33,20 @@ type VersionInfo struct {
 	APIVersion    string `json:"api_version,omitempty"`
 }
 
+// SchemaCategoryNode represents a nested taxonomy node returned by *_categories endpoints.
+type SchemaCategoryNode struct {
+	ID          int                           `json:"id"`
+	Name        string                        `json:"name"`
+	Description string                        `json:"description,omitempty"`
+	Category    bool                          `json:"category,omitempty"`
+	Caption     string                        `json:"caption,omitempty"`
+	Deprecated  bool                          `json:"deprecated,omitempty"`
+	Classes     map[string]SchemaCategoryNode `json:"classes,omitempty"`
+}
+
+// SchemaCategories is the top-level category map keyed by category slug.
+type SchemaCategories map[string]SchemaCategoryNode
+
 // SchemaOption is a function that configures schema options.
 type SchemaOption func(*schemaOptions)
 
@@ -52,21 +66,21 @@ const (
 
 // schemaOptions holds the options for schema operations.
 type schemaOptions struct {
-	version string
+	schemaVersion string
 }
 
-// WithVersion sets the schema version to use.
-func WithVersion(version string) SchemaOption {
+// WithSchemaVersion sets the schema version to use.
+func WithSchemaVersion(schemaVersion string) SchemaOption {
 	return func(opts *schemaOptions) {
-		opts.version = version
+		opts.schemaVersion = schemaVersion
 	}
 }
 
 // Schema provides access to OASF schema definitions via API.
 type Schema struct {
-	schemaURL      string // Normalized schema URL
-	httpClient     *http.Client
-	defaultVersion string // Cached default version
+	schemaURL            string // Normalized schema URL
+	httpClient           *http.Client
+	defaultSchemaVersion string // Cached default version
 }
 
 // normalizeURL normalizes a schema URL by removing trailing slashes and adding protocol if missing.
@@ -140,8 +154,8 @@ func (s *Schema) getVersionsResponse(ctx context.Context) (*VersionsResponse, er
 // GetDefaultSchemaVersion returns the default schema version, caching it after first fetch.
 // The default schema version is fetched from the server's api/versions endpoint.
 func (s *Schema) GetDefaultSchemaVersion(ctx context.Context) (string, error) {
-	if s.defaultVersion != "" {
-		return s.defaultVersion, nil
+	if s.defaultSchemaVersion != "" {
+		return s.defaultSchemaVersion, nil
 	}
 
 	versionsResp, err := s.getVersionsResponse(ctx)
@@ -149,12 +163,12 @@ func (s *Schema) GetDefaultSchemaVersion(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	s.defaultVersion = schemaVersionFromVersionInfo(versionsResp.Default)
-	if s.defaultVersion == "" {
+	s.defaultSchemaVersion = schemaVersionFromVersionInfo(versionsResp.Default)
+	if s.defaultSchemaVersion == "" {
 		return "", errors.New("default schema version is missing from /api/versions response")
 	}
 
-	return s.defaultVersion, nil
+	return s.defaultSchemaVersion, nil
 }
 
 // GetAvailableSchemaVersions returns a list of all supported schema versions from the OASF server.
@@ -202,18 +216,18 @@ func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name stri
 		opt(options)
 	}
 
-	// Use provided version or fetch default
-	version := options.version
-	if version == "" {
+	// Use provided schemaVersion or fetch default
+	schemaVersion := options.schemaVersion
+	if schemaVersion == "" {
 		var err error
 
-		version, err = s.GetDefaultSchemaVersion(ctx)
+		schemaVersion, err = s.GetDefaultSchemaVersion(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get default version: %w", err)
 		}
 	}
 
-	schemaURL := s.constructSchemaURL(version, schemaType, name)
+	schemaURL := s.constructSchemaURL(schemaVersion, schemaType, name)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaURL, nil)
 	if err != nil {
@@ -242,6 +256,53 @@ func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name stri
 	return schemaData, nil
 }
 
+// GetSchemaCategories fetches nested taxonomy categories from /api/<version>/<endpoint>.
+// The endpoint must be one of: module_categories, skill_categories, domain_categories.
+func (s *Schema) GetSchemaCategories(ctx context.Context, endpoint string, opts ...SchemaOption) (SchemaCategories, error) {
+	options := &schemaOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	version := options.schemaVersion
+	if version == "" {
+		var err error
+
+		version, err = s.GetDefaultSchemaVersion(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get default version: %w", err)
+		}
+	}
+
+	categoriesURL := fmt.Sprintf("%s/api/%s/%s", s.schemaURL, version, endpoint)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, categoriesURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GET request to %s: %w", categoriesURL, err)
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send GET request to %s: %w", categoriesURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+
+		return nil, fmt.Errorf("failed to fetch categories from URL %s: HTTP %d, body: %s", categoriesURL, resp.StatusCode, string(body))
+	}
+
+	var categories SchemaCategories
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&categories); err != nil {
+		return nil, fmt.Errorf("failed to decode categories response from URL %s: %w", categoriesURL, err)
+	}
+
+	return categories, nil
+}
+
 // GetRecordSchemaContent returns the raw JSON schema content for a given version.
 // If no version is provided via options, the default version from the server is used.
 // It fetches the "record" object schema.
@@ -257,56 +318,23 @@ func (s *Schema) GetRecordSchemaContent(ctx context.Context, opts ...SchemaOptio
 	return s.GetSchema(ctx, SchemaTypeObjects, "record", opts...)
 }
 
-// GetSchemaKey is a generic function to extract any $defs category from a schema.
-// For example, extracting skills, domains, modules, or any other $defs key.
+// GetSchemaSkills is a convenience function to fetch skill categories.
 // If no version is provided via options, the default version from the server is used.
-// Returns the category definitions as JSON bytes, or an error if not found.
-func (s *Schema) GetSchemaKey(ctx context.Context, defsKey string, opts ...SchemaOption) ([]byte, error) {
-	schemaData, err := s.GetRecordSchemaContent(ctx, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	var schemaMap map[string]any
-	if err := json.Unmarshal(schemaData, &schemaMap); err != nil {
-		return nil, fmt.Errorf("failed to parse schema: %w", err)
-	}
-
-	defs, ok := schemaMap["$defs"].(map[string]any)
-	if !ok {
-		return nil, errors.New("schema does not contain $defs section")
-	}
-
-	category, ok := defs[defsKey].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("schema does not contain '%s' definitions in $defs", defsKey)
-	}
-
-	categoryJSON, err := json.Marshal(category)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal %s: %w", defsKey, err)
-	}
-
-	return categoryJSON, nil
+// Returns nested skill categories from /api/<version>/skill_categories.
+func (s *Schema) GetSchemaSkills(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
+	return s.GetSchemaCategories(ctx, "skill_categories", opts...)
 }
 
-// GetSchemaSkills is a convenience function to extract skills from a schema.
+// GetSchemaDomains is a convenience function to fetch domain categories.
 // If no version is provided via options, the default version from the server is used.
-// Returns the skills as JSON bytes, or an error if the version is not found or parsing fails.
-func (s *Schema) GetSchemaSkills(ctx context.Context, opts ...SchemaOption) ([]byte, error) {
-	return s.GetSchemaKey(ctx, "skills", opts...)
+// Returns nested domain categories from /api/<version>/domain_categories.
+func (s *Schema) GetSchemaDomains(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
+	return s.GetSchemaCategories(ctx, "domain_categories", opts...)
 }
 
-// GetSchemaDomains is a convenience function to extract domains from a schema.
+// GetSchemaModules is a convenience function to fetch module categories.
 // If no version is provided via options, the default version from the server is used.
-// Returns the domains as JSON bytes, or an error if the version is not found or parsing fails.
-func (s *Schema) GetSchemaDomains(ctx context.Context, opts ...SchemaOption) ([]byte, error) {
-	return s.GetSchemaKey(ctx, "domains", opts...)
-}
-
-// GetSchemaModules is a convenience function to extract modules from a schema.
-// If no version is provided via options, the default version from the server is used.
-// Returns the modules as JSON bytes, or an error if the version is not found or parsing fails.
-func (s *Schema) GetSchemaModules(ctx context.Context, opts ...SchemaOption) ([]byte, error) {
-	return s.GetSchemaKey(ctx, "modules", opts...)
+// Returns nested module categories from /api/<version>/module_categories.
+func (s *Schema) GetSchemaModules(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
+	return s.GetSchemaCategories(ctx, "module_categories", opts...)
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -11,10 +11,12 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
 const defaultHTTPTimeoutSeconds = 30
+const apiVersionsPath = "/api/versions"
 
 // VersionsResponse represents the response from the api/versions endpoint.
 type VersionsResponse struct {
@@ -47,6 +49,14 @@ type SchemaCategoryNode struct {
 // SchemaCategories is the top-level category map keyed by category slug.
 type SchemaCategories map[string]SchemaCategoryNode
 
+type schemaCache struct {
+	defaultSchemaVersion    string
+	availableSchemaVersions []string
+	schemaSkills            map[string]SchemaCategories
+	schemaDomains           map[string]SchemaCategories
+	schemaModules           map[string]SchemaCategories
+}
+
 // SchemaOption is a function that configures schema options.
 type SchemaOption func(*schemaOptions)
 
@@ -76,19 +86,22 @@ func WithSchemaVersion(schemaVersion string) SchemaOption {
 	}
 }
 
+// WithVersion sets the schema version to use.
+// Deprecated: use WithSchemaVersion instead.
+func WithVersion(schemaVersion string) SchemaOption {
+	return WithSchemaVersion(schemaVersion)
+}
+
 // Schema provides access to OASF schema definitions via API.
 type Schema struct {
-	schemaURL            string // Normalized schema URL
-	httpClient           *http.Client
-	defaultSchemaVersion string // Cached default version
+	schemaURL  string // Normalized schema URL
+	httpClient *http.Client
+	cache      atomic.Pointer[schemaCache]
 }
 
 // normalizeURL normalizes a schema URL by removing trailing slashes and adding protocol if missing.
 func normalizeURL(schemaURL string) string {
-	// Normalize the base URL (remove trailing slash if present)
 	normalizedURL := strings.TrimSuffix(schemaURL, "/")
-
-	// Add protocol if missing (default to http:// for localhost or IP addresses)
 	if !strings.HasPrefix(normalizedURL, "http://") && !strings.HasPrefix(normalizedURL, "https://") {
 		normalizedURL = "http://" + normalizedURL
 	}
@@ -97,8 +110,6 @@ func normalizeURL(schemaURL string) string {
 }
 
 // New creates a new Schema instance with the given schema base URL.
-// The base URL should point to the OASF schema API endpoint (e.g., https://schema.oasf.outshift.com).
-// The URL will be normalized (trailing slashes removed, protocol added if missing).
 func New(schemaURL string) (*Schema, error) {
 	if schemaURL == "" {
 		return nil, errors.New("schema URL is required")
@@ -112,22 +123,39 @@ func New(schemaURL string) (*Schema, error) {
 	}, nil
 }
 
-const apiVersionsPath = "/api/versions"
+func schemaVersionFromVersionInfo(versionInfo VersionInfo) string {
+	if versionInfo.SchemaVersion != "" {
+		return versionInfo.SchemaVersion
+	}
+
+	return versionInfo.Version
+}
+
+// cloneCategories deep-copies SchemaCategories before returning it to callers.
+// SchemaCategories is a map type, so returning cached maps directly would expose
+// mutable internal cache state and allow external code to modify it.
+func cloneCategories(src SchemaCategories) SchemaCategories {
+	dst := make(SchemaCategories, len(src))
+	for k, v := range src {
+		copied := v
+		if len(v.Classes) > 0 {
+			copied.Classes = cloneCategories(v.Classes)
+		}
+		dst[k] = copied
+	}
+
+	return dst
+}
 
 // getVersionsResponse fetches the versions response from the server.
 func (s *Schema) getVersionsResponse(ctx context.Context) (*VersionsResponse, error) {
-	// Construct the versions endpoint URL
 	versionsURL := s.schemaURL + apiVersionsPath
-
-	// Create GET request with context
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, versionsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GET request to %s: %w", versionsURL, err)
 	}
-
 	req.Header.Set("Accept", "application/json")
 
-	// Send request
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send GET request to %s: %w", versionsURL, err)
@@ -136,13 +164,10 @@ func (s *Schema) getVersionsResponse(ctx context.Context) (*VersionsResponse, er
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-
 		return nil, fmt.Errorf("failed to fetch versions from URL %s: HTTP %d, body: %s", versionsURL, resp.StatusCode, string(body))
 	}
 
-	// Read and parse response
 	var versionsResp VersionsResponse
-
 	decoder := json.NewDecoder(resp.Body)
 	if err := decoder.Decode(&versionsResp); err != nil {
 		return nil, fmt.Errorf("failed to decode versions response from URL %s: %w", versionsURL, err)
@@ -151,11 +176,11 @@ func (s *Schema) getVersionsResponse(ctx context.Context) (*VersionsResponse, er
 	return &versionsResp, nil
 }
 
-// GetDefaultSchemaVersion returns the default schema version, caching it after first fetch.
-// The default schema version is fetched from the server's api/versions endpoint.
+// GetDefaultSchemaVersion returns the default schema version.
+// If cache exists, it is served from cache.
 func (s *Schema) GetDefaultSchemaVersion(ctx context.Context) (string, error) {
-	if s.defaultSchemaVersion != "" {
-		return s.defaultSchemaVersion, nil
+	if cached := s.cache.Load(); cached != nil && cached.defaultSchemaVersion != "" {
+		return cached.defaultSchemaVersion, nil
 	}
 
 	versionsResp, err := s.getVersionsResponse(ctx)
@@ -163,23 +188,26 @@ func (s *Schema) GetDefaultSchemaVersion(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	s.defaultSchemaVersion = schemaVersionFromVersionInfo(versionsResp.Default)
-	if s.defaultSchemaVersion == "" {
+	defaultSchemaVersion := schemaVersionFromVersionInfo(versionsResp.Default)
+	if defaultSchemaVersion == "" {
 		return "", errors.New("default schema version is missing from /api/versions response")
 	}
 
-	return s.defaultSchemaVersion, nil
+	return defaultSchemaVersion, nil
 }
 
-// GetAvailableSchemaVersions returns a list of all supported schema versions from the OASF server.
-// It fetches the versions from the api/versions endpoint.
+// GetAvailableSchemaVersions returns supported schema versions.
+// If cache exists, it is served from cache.
 func (s *Schema) GetAvailableSchemaVersions(ctx context.Context) ([]string, error) {
+	if cached := s.cache.Load(); cached != nil && len(cached.availableSchemaVersions) > 0 {
+		return append([]string(nil), cached.availableSchemaVersions...), nil
+	}
+
 	versionsResp, err := s.getVersionsResponse(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Extract schema version strings from the response
 	schemaVersions := make([]string, 0, len(versionsResp.Versions))
 	for _, v := range versionsResp.Versions {
 		schemaVersion := schemaVersionFromVersionInfo(v)
@@ -191,95 +219,73 @@ func (s *Schema) GetAvailableSchemaVersions(ctx context.Context) ([]string, erro
 	return schemaVersions, nil
 }
 
-// constructSchemaURL builds the schema URL from options.
-// Format: /schema/<version>/<type>/<name>.
-func (s *Schema) constructSchemaURL(version string, schemaType SchemaType, name string) string {
-	return fmt.Sprintf("%s/schema/%s/%s/%s", s.schemaURL, version, schemaType, name)
-}
-
-func schemaVersionFromVersionInfo(versionInfo VersionInfo) string {
-	if versionInfo.SchemaVersion != "" {
-		return versionInfo.SchemaVersion
+func (s *Schema) ensureVersionSupported(ctx context.Context, schemaVersion string) error {
+	versions, err := s.GetAvailableSchemaVersions(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get available versions: %w", err)
 	}
 
-	return versionInfo.Version
-}
-
-// GetSchema is a generic function to fetch schema content from the OASF API.
-// It constructs the URL as /schema/<version>/<type>/<name>.
-// schemaType must be one of: objects, modules, skills, or domains.
-// name specifies the specific schema name (e.g., "agent", "record", or specific module/skill/domain name).
-// If no version is provided via options, the default version is used.
-func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name string, opts ...SchemaOption) ([]byte, error) {
-	options := &schemaOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	// Use provided schemaVersion or fetch default
-	schemaVersion := options.schemaVersion
-	if schemaVersion == "" {
-		var err error
-
-		schemaVersion, err = s.GetDefaultSchemaVersion(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get default version: %w", err)
+	for _, v := range versions {
+		if v == schemaVersion {
+			return nil
 		}
 	}
 
-	schemaURL := s.constructSchemaURL(schemaVersion, schemaType, name)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create GET request to %s: %w", schemaURL, err)
-	}
-
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := s.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send GET request to %s: %w", schemaURL, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-
-		return nil, fmt.Errorf("failed to fetch schema from URL %s: HTTP %d, body: %s", schemaURL, resp.StatusCode, string(body))
-	}
-
-	schemaData, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read schema response from URL %s: %w", schemaURL, err)
-	}
-
-	return schemaData, nil
+	return fmt.Errorf("schema version %q is not supported", schemaVersion)
 }
 
-// GetSchemaCategories fetches nested taxonomy categories from /api/<version>/<endpoint>.
-// The endpoint must be one of: module_categories, skill_categories, domain_categories.
-func (s *Schema) GetSchemaCategories(ctx context.Context, endpoint string, opts ...SchemaOption) (SchemaCategories, error) {
-	options := &schemaOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
-
-	version := options.schemaVersion
-	if version == "" {
-		var err error
-
-		version, err = s.GetDefaultSchemaVersion(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get default version: %w", err)
+func (s *Schema) resolveVersion(ctx context.Context, schemaVersion string) (string, error) {
+	if schemaVersion != "" {
+		if err := s.ensureVersionSupported(ctx, schemaVersion); err != nil {
+			return "", err
 		}
+		return schemaVersion, nil
 	}
 
+	defaultSchemaVersion, err := s.GetDefaultSchemaVersion(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to get default version: %w", err)
+	}
+
+	return defaultSchemaVersion, nil
+}
+
+func (s *Schema) getCachedCategories(endpoint string, schemaVersion string) (SchemaCategories, bool) {
+	cached := s.cache.Load()
+	if cached == nil {
+		return nil, false
+	}
+
+	switch endpoint {
+	case "skill_categories":
+		c, ok := cached.schemaSkills[schemaVersion]
+		if !ok {
+			return nil, false
+		}
+		return cloneCategories(c), true
+	case "domain_categories":
+		c, ok := cached.schemaDomains[schemaVersion]
+		if !ok {
+			return nil, false
+		}
+		return cloneCategories(c), true
+	case "module_categories":
+		c, ok := cached.schemaModules[schemaVersion]
+		if !ok {
+			return nil, false
+		}
+		return cloneCategories(c), true
+	default:
+		return nil, false
+	}
+}
+
+func (s *Schema) fetchCategoriesForVersion(ctx context.Context, version string, endpoint string) (SchemaCategories, error) {
 	categoriesURL := fmt.Sprintf("%s/api/%s/%s", s.schemaURL, version, endpoint)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, categoriesURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GET request to %s: %w", categoriesURL, err)
 	}
-
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.httpClient.Do(req)
@@ -290,7 +296,6 @@ func (s *Schema) GetSchemaCategories(ctx context.Context, endpoint string, opts 
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-
 		return nil, fmt.Errorf("failed to fetch categories from URL %s: HTTP %d, body: %s", categoriesURL, resp.StatusCode, string(body))
 	}
 
@@ -303,38 +308,138 @@ func (s *Schema) GetSchemaCategories(ctx context.Context, endpoint string, opts 
 	return categories, nil
 }
 
-// GetRecordSchemaContent returns the raw JSON schema content for a given version.
-// If no version is provided via options, the default version from the server is used.
-// It fetches the "record" object schema.
-// Returns an error if the version is not found or if there's an issue fetching the schema.
-func (s *Schema) GetRecordSchemaContent(ctx context.Context, opts ...SchemaOption) ([]byte, error) {
-	// Parse options to get version if provided
+// Cache preloads and snapshots supported versions and nested categories.
+// Snapshot is version-keyed and immutable until Cache is called again.
+func (s *Schema) Cache(ctx context.Context) error {
+	versionsResp, err := s.getVersionsResponse(ctx)
+	if err != nil {
+		return err
+	}
+
+	defaultSchemaVersion := schemaVersionFromVersionInfo(versionsResp.Default)
+	if defaultSchemaVersion == "" {
+		return errors.New("default schema version is missing from /api/versions response")
+	}
+
+	schemaVersions := make([]string, 0, len(versionsResp.Versions))
+	for _, v := range versionsResp.Versions {
+		schemaVersion := schemaVersionFromVersionInfo(v)
+		if schemaVersion != "" {
+			schemaVersions = append(schemaVersions, schemaVersion)
+		}
+	}
+
+	next := &schemaCache{
+		defaultSchemaVersion:    defaultSchemaVersion,
+		availableSchemaVersions: append([]string(nil), schemaVersions...),
+		schemaSkills:            make(map[string]SchemaCategories, len(schemaVersions)),
+		schemaDomains:           make(map[string]SchemaCategories, len(schemaVersions)),
+		schemaModules:           make(map[string]SchemaCategories, len(schemaVersions)),
+	}
+
+	for _, version := range schemaVersions {
+		skills, err := s.fetchCategoriesForVersion(ctx, version, "skill_categories")
+		if err != nil {
+			return fmt.Errorf("failed to cache skills for version %s: %w", version, err)
+		}
+		domains, err := s.fetchCategoriesForVersion(ctx, version, "domain_categories")
+		if err != nil {
+			return fmt.Errorf("failed to cache domains for version %s: %w", version, err)
+		}
+		modules, err := s.fetchCategoriesForVersion(ctx, version, "module_categories")
+		if err != nil {
+			return fmt.Errorf("failed to cache modules for version %s: %w", version, err)
+		}
+
+		next.schemaSkills[version] = cloneCategories(skills)
+		next.schemaDomains[version] = cloneCategories(domains)
+		next.schemaModules[version] = cloneCategories(modules)
+	}
+
+	s.cache.Store(next)
+	return nil
+}
+
+// constructSchemaURL builds the schema URL from options.
+// Format: /schema/<version>/<type>/<name>.
+func (s *Schema) constructSchemaURL(version string, schemaType SchemaType, name string) string {
+	return fmt.Sprintf("%s/schema/%s/%s/%s", s.schemaURL, version, schemaType, name)
+}
+
+// GetSchema is a generic function to fetch schema content from the OASF API.
+// It constructs the URL as /schema/<version>/<type>/<name>.
+func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name string, opts ...SchemaOption) ([]byte, error) {
 	options := &schemaOptions{}
 	for _, opt := range opts {
 		opt(options)
 	}
 
-	// Use the generic GetSchema function
+	schemaVersion, err := s.resolveVersion(ctx, options.schemaVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaURL := s.constructSchemaURL(schemaVersion, schemaType, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GET request to %s: %w", schemaURL, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send GET request to %s: %w", schemaURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("failed to fetch schema from URL %s: HTTP %d, body: %s", schemaURL, resp.StatusCode, string(body))
+	}
+
+	schemaData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schema response from URL %s: %w", schemaURL, err)
+	}
+
+	return schemaData, nil
+}
+
+// GetSchemaCategories fetches nested taxonomy categories from /api/<version>/<endpoint>.
+func (s *Schema) GetSchemaCategories(ctx context.Context, endpoint string, opts ...SchemaOption) (SchemaCategories, error) {
+	options := &schemaOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	version, err := s.resolveVersion(ctx, options.schemaVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	if categories, ok := s.getCachedCategories(endpoint, version); ok {
+		return categories, nil
+	}
+
+	return s.fetchCategoriesForVersion(ctx, version, endpoint)
+}
+
+// GetRecordSchemaContent returns the raw JSON schema content for a given version.
+func (s *Schema) GetRecordSchemaContent(ctx context.Context, opts ...SchemaOption) ([]byte, error) {
 	return s.GetSchema(ctx, SchemaTypeObjects, "record", opts...)
 }
 
-// GetSchemaSkills is a convenience function to fetch skill categories.
-// If no version is provided via options, the default version from the server is used.
-// Returns nested skill categories from /api/<version>/skill_categories.
+// GetSchemaSkills returns nested skill categories from /api/<version>/skill_categories.
 func (s *Schema) GetSchemaSkills(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
 	return s.GetSchemaCategories(ctx, "skill_categories", opts...)
 }
 
-// GetSchemaDomains is a convenience function to fetch domain categories.
-// If no version is provided via options, the default version from the server is used.
-// Returns nested domain categories from /api/<version>/domain_categories.
+// GetSchemaDomains returns nested domain categories from /api/<version>/domain_categories.
 func (s *Schema) GetSchemaDomains(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
 	return s.GetSchemaCategories(ctx, "domain_categories", opts...)
 }
 
-// GetSchemaModules is a convenience function to fetch module categories.
-// If no version is provided via options, the default version from the server is used.
-// Returns nested module categories from /api/<version>/module_categories.
+// GetSchemaModules returns nested module categories from /api/<version>/module_categories.
 func (s *Schema) GetSchemaModules(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
 	return s.GetSchemaCategories(ctx, "module_categories", opts...)
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -360,6 +360,16 @@ func (s *Schema) Cache(ctx context.Context) error {
 	return nil
 }
 
+// ReloadCache refreshes the full cache snapshot.
+func (s *Schema) ReloadCache(ctx context.Context) error {
+	return s.Cache(ctx)
+}
+
+// ClearCache removes the current cache snapshot.
+func (s *Schema) ClearCache() {
+	s.cache.Store(nil)
+}
+
 // constructSchemaURL builds the schema URL from options.
 // Format: /schema/<version>/<type>/<name>.
 func (s *Schema) constructSchemaURL(version string, schemaType SchemaType, name string) string {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -12,13 +12,16 @@ import (
 	"net/http"
 	"slices"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"time"
 )
 
 const (
 	defaultHTTPTimeoutSeconds = 30
 	apiVersionsPath           = "/api/versions"
+	skillCategoriesEndpoint   = "skill_categories"
+	domainCategoriesEndpoint  = "domain_categories"
+	moduleCategoriesEndpoint  = "module_categories"
 )
 
 // VersionsResponse represents the response from the api/versions endpoint.
@@ -56,10 +59,20 @@ type schemaCache struct {
 	schemaSkills            map[string]SchemaCategories
 	schemaDomains           map[string]SchemaCategories
 	schemaModules           map[string]SchemaCategories
+	jsonSchema              map[string]map[string]jsonSchemaCacheEntry
 }
 
-// SchemaOption is a function that configures schema options.
+type jsonSchemaCacheEntry struct {
+	schemaType SchemaType
+	name       string
+	data       []byte
+}
+
+// SchemaOption is a function that configures schema query options.
 type SchemaOption func(*schemaOptions)
+
+// ConstructorOption is a function that configures schema client behavior.
+type ConstructorOption func(*constructorOptions)
 
 // SchemaType represents the type of schema to fetch.
 type SchemaType string
@@ -75,6 +88,18 @@ const (
 	SchemaTypeDomains SchemaType = "domains"
 )
 
+type constructorOptions struct {
+	enableCache bool
+}
+
+// WithCache enables or disables dynamic in-memory caching.
+// Disabled by default.
+func WithCache(enabled bool) ConstructorOption {
+	return func(opts *constructorOptions) {
+		opts.enableCache = enabled
+	}
+}
+
 // schemaOptions holds the options for schema operations.
 type schemaOptions struct {
 	schemaVersion string
@@ -89,9 +114,11 @@ func WithSchemaVersion(schemaVersion string) SchemaOption {
 
 // Schema provides access to OASF schema definitions via API.
 type Schema struct {
-	schemaURL  string // Normalized schema URL
-	httpClient *http.Client
-	cache      atomic.Pointer[schemaCache]
+	schemaURL    string // Normalized schema URL
+	httpClient   *http.Client
+	cacheEnabled bool
+	cacheMu      sync.RWMutex
+	cache        *schemaCache
 }
 
 // normalizeURL normalizes a schema URL by removing trailing slashes and adding protocol if missing.
@@ -105,15 +132,27 @@ func normalizeURL(schemaURL string) string {
 }
 
 // New creates a new Schema instance with the given schema base URL.
-func New(schemaURL string) (*Schema, error) {
+func New(schemaURL string, opts ...ConstructorOption) (*Schema, error) {
 	if schemaURL == "" {
 		return nil, errors.New("schema URL is required")
 	}
 
+	options := &constructorOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
 	return &Schema{
-		schemaURL: normalizeURL(schemaURL),
+		schemaURL:    normalizeURL(schemaURL),
+		cacheEnabled: options.enableCache,
 		httpClient: &http.Client{
 			Timeout: defaultHTTPTimeoutSeconds * time.Second,
+		},
+		cache: &schemaCache{
+			schemaSkills:  map[string]SchemaCategories{},
+			schemaDomains: map[string]SchemaCategories{},
+			schemaModules: map[string]SchemaCategories{},
+			jsonSchema:    map[string]map[string]jsonSchemaCacheEntry{},
 		},
 	}, nil
 }
@@ -133,6 +172,22 @@ func cloneCategories(src SchemaCategories) SchemaCategories {
 	}
 
 	return dst
+}
+
+func (s *Schema) extractVersions(resp *VersionsResponse) (string, []string, error) {
+	defaultSchemaVersion := resp.Default.SchemaVersion
+	if defaultSchemaVersion == "" {
+		return "", nil, errors.New("default schema version is missing from /api/versions response")
+	}
+
+	schemaVersions := make([]string, 0, len(resp.Versions))
+	for _, v := range resp.Versions {
+		if v.SchemaVersion != "" {
+			schemaVersions = append(schemaVersions, v.SchemaVersion)
+		}
+	}
+
+	return defaultSchemaVersion, schemaVersions, nil
 }
 
 // getVersionsResponse fetches the versions response from the server.
@@ -169,10 +224,16 @@ func (s *Schema) getVersionsResponse(ctx context.Context) (*VersionsResponse, er
 }
 
 // GetDefaultSchemaVersion returns the default schema version.
-// If cache exists, it is served from cache.
 func (s *Schema) GetDefaultSchemaVersion(ctx context.Context) (string, error) {
-	if cached := s.cache.Load(); cached != nil && cached.defaultSchemaVersion != "" {
-		return cached.defaultSchemaVersion, nil
+	if s.cacheEnabled {
+		s.cacheMu.RLock()
+
+		defaultSchemaVersion := s.cache.defaultSchemaVersion
+		s.cacheMu.RUnlock()
+
+		if defaultSchemaVersion != "" {
+			return defaultSchemaVersion, nil
+		}
 	}
 
 	versionsResp, err := s.getVersionsResponse(ctx)
@@ -180,19 +241,33 @@ func (s *Schema) GetDefaultSchemaVersion(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	defaultSchemaVersion := versionsResp.Default.SchemaVersion
-	if defaultSchemaVersion == "" {
-		return "", errors.New("default schema version is missing from /api/versions response")
+	defaultSchemaVersion, schemaVersions, err := s.extractVersions(versionsResp)
+	if err != nil {
+		return "", err
+	}
+
+	if s.cacheEnabled {
+		s.cacheMu.Lock()
+		s.cache.defaultSchemaVersion = defaultSchemaVersion
+
+		s.cache.availableSchemaVersions = append([]string(nil), schemaVersions...)
+		s.cacheMu.Unlock()
 	}
 
 	return defaultSchemaVersion, nil
 }
 
 // GetAvailableSchemaVersions returns supported schema versions.
-// If cache exists, it is served from cache.
 func (s *Schema) GetAvailableSchemaVersions(ctx context.Context) ([]string, error) {
-	if cached := s.cache.Load(); cached != nil && len(cached.availableSchemaVersions) > 0 {
-		return append([]string(nil), cached.availableSchemaVersions...), nil
+	if s.cacheEnabled {
+		s.cacheMu.RLock()
+
+		cachedVersions := append([]string(nil), s.cache.availableSchemaVersions...)
+		s.cacheMu.RUnlock()
+
+		if len(cachedVersions) > 0 {
+			return cachedVersions, nil
+		}
 	}
 
 	versionsResp, err := s.getVersionsResponse(ctx)
@@ -200,12 +275,17 @@ func (s *Schema) GetAvailableSchemaVersions(ctx context.Context) ([]string, erro
 		return nil, err
 	}
 
-	schemaVersions := make([]string, 0, len(versionsResp.Versions))
-	for _, v := range versionsResp.Versions {
-		schemaVersion := v.SchemaVersion
-		if schemaVersion != "" {
-			schemaVersions = append(schemaVersions, schemaVersion)
-		}
+	defaultSchemaVersion, schemaVersions, err := s.extractVersions(versionsResp)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.cacheEnabled {
+		s.cacheMu.Lock()
+		s.cache.defaultSchemaVersion = defaultSchemaVersion
+
+		s.cache.availableSchemaVersions = append([]string(nil), schemaVersions...)
+		s.cacheMu.Unlock()
 	}
 
 	return schemaVersions, nil
@@ -242,28 +322,30 @@ func (s *Schema) resolveVersion(ctx context.Context, schemaVersion string) (stri
 }
 
 func (s *Schema) getCachedCategories(endpoint string, schemaVersion string) (SchemaCategories, bool) {
-	cached := s.cache.Load()
-	if cached == nil {
+	if !s.cacheEnabled {
 		return nil, false
 	}
 
+	s.cacheMu.RLock()
+	defer s.cacheMu.RUnlock()
+
 	switch endpoint {
-	case "skill_categories":
-		c, ok := cached.schemaSkills[schemaVersion]
+	case skillCategoriesEndpoint:
+		c, ok := s.cache.schemaSkills[schemaVersion]
 		if !ok {
 			return nil, false
 		}
 
 		return cloneCategories(c), true
-	case "domain_categories":
-		c, ok := cached.schemaDomains[schemaVersion]
+	case domainCategoriesEndpoint:
+		c, ok := s.cache.schemaDomains[schemaVersion]
 		if !ok {
 			return nil, false
 		}
 
 		return cloneCategories(c), true
-	case "module_categories":
-		c, ok := cached.schemaModules[schemaVersion]
+	case moduleCategoriesEndpoint:
+		c, ok := s.cache.schemaModules[schemaVersion]
 		if !ok {
 			return nil, false
 		}
@@ -271,6 +353,70 @@ func (s *Schema) getCachedCategories(endpoint string, schemaVersion string) (Sch
 		return cloneCategories(c), true
 	default:
 		return nil, false
+	}
+}
+
+func (s *Schema) setCachedCategories(endpoint string, schemaVersion string, categories SchemaCategories) {
+	if !s.cacheEnabled {
+		return
+	}
+
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	switch endpoint {
+	case skillCategoriesEndpoint:
+		s.cache.schemaSkills[schemaVersion] = cloneCategories(categories)
+	case domainCategoriesEndpoint:
+		s.cache.schemaDomains[schemaVersion] = cloneCategories(categories)
+	case moduleCategoriesEndpoint:
+		s.cache.schemaModules[schemaVersion] = cloneCategories(categories)
+	}
+}
+
+func jsonSchemaCacheKey(schemaType SchemaType, name string) string {
+	return fmt.Sprintf("%s|%s", schemaType, name)
+}
+
+func (s *Schema) getCachedJSONSchema(schemaVersion string, schemaType SchemaType, name string) ([]byte, bool) {
+	if !s.cacheEnabled {
+		return nil, false
+	}
+
+	s.cacheMu.RLock()
+	defer s.cacheMu.RUnlock()
+
+	byVersion, ok := s.cache.jsonSchema[schemaVersion]
+	if !ok {
+		return nil, false
+	}
+
+	entry, ok := byVersion[jsonSchemaCacheKey(schemaType, name)]
+	if !ok {
+		return nil, false
+	}
+
+	return append([]byte(nil), entry.data...), true
+}
+
+func (s *Schema) setCachedJSONSchema(schemaVersion string, schemaType SchemaType, name string, data []byte) {
+	if !s.cacheEnabled {
+		return
+	}
+
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	byVersion, ok := s.cache.jsonSchema[schemaVersion]
+	if !ok {
+		byVersion = map[string]jsonSchemaCacheEntry{}
+		s.cache.jsonSchema[schemaVersion] = byVersion
+	}
+
+	byVersion[jsonSchemaCacheKey(schemaType, name)] = jsonSchemaCacheEntry{
+		schemaType: schemaType,
+		name:       name,
+		data:       append([]byte(nil), data...),
 	}
 }
 
@@ -306,69 +452,20 @@ func (s *Schema) fetchCategoriesForVersion(ctx context.Context, version string, 
 	return categories, nil
 }
 
-// Cache preloads and snapshots supported versions and nested categories.
-// Snapshot is version-keyed and immutable until Cache is called again.
-func (s *Schema) Cache(ctx context.Context) error {
-	versionsResp, err := s.getVersionsResponse(ctx)
-	if err != nil {
-		return err
-	}
-
-	defaultSchemaVersion := versionsResp.Default.SchemaVersion
-	if defaultSchemaVersion == "" {
-		return errors.New("default schema version is missing from /api/versions response")
-	}
-
-	schemaVersions := make([]string, 0, len(versionsResp.Versions))
-	for _, v := range versionsResp.Versions {
-		schemaVersion := v.SchemaVersion
-		if schemaVersion != "" {
-			schemaVersions = append(schemaVersions, schemaVersion)
-		}
-	}
-
-	next := &schemaCache{
-		defaultSchemaVersion:    defaultSchemaVersion,
-		availableSchemaVersions: append([]string(nil), schemaVersions...),
-		schemaSkills:            make(map[string]SchemaCategories, len(schemaVersions)),
-		schemaDomains:           make(map[string]SchemaCategories, len(schemaVersions)),
-		schemaModules:           make(map[string]SchemaCategories, len(schemaVersions)),
-	}
-
-	for _, version := range schemaVersions {
-		skills, err := s.fetchCategoriesForVersion(ctx, version, "skill_categories")
-		if err != nil {
-			return fmt.Errorf("failed to cache skills for version %s: %w", version, err)
-		}
-
-		domains, err := s.fetchCategoriesForVersion(ctx, version, "domain_categories")
-		if err != nil {
-			return fmt.Errorf("failed to cache domains for version %s: %w", version, err)
-		}
-
-		modules, err := s.fetchCategoriesForVersion(ctx, version, "module_categories")
-		if err != nil {
-			return fmt.Errorf("failed to cache modules for version %s: %w", version, err)
-		}
-
-		next.schemaSkills[version] = cloneCategories(skills)
-		next.schemaDomains[version] = cloneCategories(domains)
-		next.schemaModules[version] = cloneCategories(modules)
-	}
-
-	s.cache.Store(next)
-
-	return nil
-}
-
-// ReloadCache refreshes the full cache snapshot.
-func (s *Schema) ReloadCache(ctx context.Context) error {
-	return s.Cache(ctx)
-}
-
 // ClearCache removes the current cache snapshot.
 func (s *Schema) ClearCache() {
-	s.cache.Store(nil)
+	if !s.cacheEnabled {
+		return
+	}
+
+	s.cacheMu.Lock()
+	s.cache = &schemaCache{
+		schemaSkills:  map[string]SchemaCategories{},
+		schemaDomains: map[string]SchemaCategories{},
+		schemaModules: map[string]SchemaCategories{},
+		jsonSchema:    map[string]map[string]jsonSchemaCacheEntry{},
+	}
+	s.cacheMu.Unlock()
 }
 
 // constructSchemaURL builds the schema URL from options.
@@ -377,9 +474,9 @@ func (s *Schema) constructSchemaURL(version string, schemaType SchemaType, name 
 	return fmt.Sprintf("%s/schema/%s/%s/%s", s.schemaURL, version, schemaType, name)
 }
 
-// GetSchema is a generic function to fetch schema content from the OASF API.
+// GetJSONSchema is a generic function to fetch JSON schema content from the OASF API.
 // It constructs the URL as /schema/<version>/<type>/<name>.
-func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name string, opts ...SchemaOption) ([]byte, error) {
+func (s *Schema) GetJSONSchema(ctx context.Context, schemaType SchemaType, name string, opts ...SchemaOption) ([]byte, error) {
 	options := &schemaOptions{}
 	for _, opt := range opts {
 		opt(options)
@@ -388,6 +485,10 @@ func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name stri
 	schemaVersion, err := s.resolveVersion(ctx, options.schemaVersion)
 	if err != nil {
 		return nil, err
+	}
+
+	if cached, ok := s.getCachedJSONSchema(schemaVersion, schemaType, name); ok {
+		return cached, nil
 	}
 
 	schemaURL := s.constructSchemaURL(schemaVersion, schemaType, name)
@@ -416,6 +517,8 @@ func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name stri
 		return nil, fmt.Errorf("failed to read schema response from URL %s: %w", schemaURL, err)
 	}
 
+	s.setCachedJSONSchema(schemaVersion, schemaType, name, schemaData)
+
 	return schemaData, nil
 }
 
@@ -435,25 +538,32 @@ func (s *Schema) GetSchemaCategories(ctx context.Context, endpoint string, opts 
 		return categories, nil
 	}
 
-	return s.fetchCategoriesForVersion(ctx, version, endpoint)
+	categories, err := s.fetchCategoriesForVersion(ctx, version, endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	s.setCachedCategories(endpoint, version, categories)
+
+	return categories, nil
 }
 
-// GetRecordSchemaContent returns the raw JSON schema content for a given version.
-func (s *Schema) GetRecordSchemaContent(ctx context.Context, opts ...SchemaOption) ([]byte, error) {
-	return s.GetSchema(ctx, SchemaTypeObjects, "record", opts...)
+// GetRecordJSONSchema returns the record JSON schema content for a given version.
+func (s *Schema) GetRecordJSONSchema(ctx context.Context, opts ...SchemaOption) ([]byte, error) {
+	return s.GetJSONSchema(ctx, SchemaTypeObjects, "record", opts...)
 }
 
 // GetSchemaSkills returns nested skill categories from /api/<version>/skill_categories.
 func (s *Schema) GetSchemaSkills(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
-	return s.GetSchemaCategories(ctx, "skill_categories", opts...)
+	return s.GetSchemaCategories(ctx, skillCategoriesEndpoint, opts...)
 }
 
 // GetSchemaDomains returns nested domain categories from /api/<version>/domain_categories.
 func (s *Schema) GetSchemaDomains(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
-	return s.GetSchemaCategories(ctx, "domain_categories", opts...)
+	return s.GetSchemaCategories(ctx, domainCategoriesEndpoint, opts...)
 }
 
 // GetSchemaModules returns nested module categories from /api/<version>/module_categories.
 func (s *Schema) GetSchemaModules(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
-	return s.GetSchemaCategories(ctx, "module_categories", opts...)
+	return s.GetSchemaCategories(ctx, moduleCategoriesEndpoint, opts...)
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -25,9 +25,7 @@ type VersionsResponse struct {
 }
 
 // VersionInfo represents schema server version metadata.
-// The API has evolved over time, so we support both legacy and v0.6.0 fields.
 type VersionInfo struct {
-	Version       string `json:"version,omitempty"`
 	SchemaVersion string `json:"schema_version"`
 	URL           string `json:"url,omitempty"`
 	APIURL        string `json:"api_url,omitempty"`
@@ -86,12 +84,6 @@ func WithSchemaVersion(schemaVersion string) SchemaOption {
 	}
 }
 
-// WithVersion sets the schema version to use.
-// Deprecated: use WithSchemaVersion instead.
-func WithVersion(schemaVersion string) SchemaOption {
-	return WithSchemaVersion(schemaVersion)
-}
-
 // Schema provides access to OASF schema definitions via API.
 type Schema struct {
 	schemaURL  string // Normalized schema URL
@@ -121,14 +113,6 @@ func New(schemaURL string) (*Schema, error) {
 			Timeout: defaultHTTPTimeoutSeconds * time.Second,
 		},
 	}, nil
-}
-
-func schemaVersionFromVersionInfo(versionInfo VersionInfo) string {
-	if versionInfo.SchemaVersion != "" {
-		return versionInfo.SchemaVersion
-	}
-
-	return versionInfo.Version
 }
 
 // cloneCategories deep-copies SchemaCategories before returning it to callers.
@@ -188,7 +172,7 @@ func (s *Schema) GetDefaultSchemaVersion(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	defaultSchemaVersion := schemaVersionFromVersionInfo(versionsResp.Default)
+	defaultSchemaVersion := versionsResp.Default.SchemaVersion
 	if defaultSchemaVersion == "" {
 		return "", errors.New("default schema version is missing from /api/versions response")
 	}
@@ -210,7 +194,7 @@ func (s *Schema) GetAvailableSchemaVersions(ctx context.Context) ([]string, erro
 
 	schemaVersions := make([]string, 0, len(versionsResp.Versions))
 	for _, v := range versionsResp.Versions {
-		schemaVersion := schemaVersionFromVersionInfo(v)
+		schemaVersion := v.SchemaVersion
 		if schemaVersion != "" {
 			schemaVersions = append(schemaVersions, schemaVersion)
 		}
@@ -316,14 +300,14 @@ func (s *Schema) Cache(ctx context.Context) error {
 		return err
 	}
 
-	defaultSchemaVersion := schemaVersionFromVersionInfo(versionsResp.Default)
+	defaultSchemaVersion := versionsResp.Default.SchemaVersion
 	if defaultSchemaVersion == "" {
 		return errors.New("default schema version is missing from /api/versions response")
 	}
 
 	schemaVersions := make([]string, 0, len(versionsResp.Versions))
 	for _, v := range versionsResp.Versions {
-		schemaVersion := schemaVersionFromVersionInfo(v)
+		schemaVersion := v.SchemaVersion
 		if schemaVersion != "" {
 			schemaVersions = append(schemaVersions, schemaVersion)
 		}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -10,13 +10,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
 )
 
-const defaultHTTPTimeoutSeconds = 30
-const apiVersionsPath = "/api/versions"
+const (
+	defaultHTTPTimeoutSeconds = 30
+	apiVersionsPath           = "/api/versions"
+)
 
 // VersionsResponse represents the response from the api/versions endpoint.
 type VersionsResponse struct {
@@ -125,6 +128,7 @@ func cloneCategories(src SchemaCategories) SchemaCategories {
 		if len(v.Classes) > 0 {
 			copied.Classes = cloneCategories(v.Classes)
 		}
+
 		dst[k] = copied
 	}
 
@@ -134,10 +138,12 @@ func cloneCategories(src SchemaCategories) SchemaCategories {
 // getVersionsResponse fetches the versions response from the server.
 func (s *Schema) getVersionsResponse(ctx context.Context) (*VersionsResponse, error) {
 	versionsURL := s.schemaURL + apiVersionsPath
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, versionsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GET request to %s: %w", versionsURL, err)
 	}
+
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.httpClient.Do(req)
@@ -148,10 +154,12 @@ func (s *Schema) getVersionsResponse(ctx context.Context) (*VersionsResponse, er
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("failed to fetch versions from URL %s: HTTP %d, body: %s", versionsURL, resp.StatusCode, string(body))
 	}
 
 	var versionsResp VersionsResponse
+
 	decoder := json.NewDecoder(resp.Body)
 	if err := decoder.Decode(&versionsResp); err != nil {
 		return nil, fmt.Errorf("failed to decode versions response from URL %s: %w", versionsURL, err)
@@ -209,10 +217,8 @@ func (s *Schema) ensureVersionSupported(ctx context.Context, schemaVersion strin
 		return fmt.Errorf("failed to get available versions: %w", err)
 	}
 
-	for _, v := range versions {
-		if v == schemaVersion {
-			return nil
-		}
+	if slices.Contains(versions, schemaVersion) {
+		return nil
 	}
 
 	return fmt.Errorf("schema version %q is not supported", schemaVersion)
@@ -223,6 +229,7 @@ func (s *Schema) resolveVersion(ctx context.Context, schemaVersion string) (stri
 		if err := s.ensureVersionSupported(ctx, schemaVersion); err != nil {
 			return "", err
 		}
+
 		return schemaVersion, nil
 	}
 
@@ -246,18 +253,21 @@ func (s *Schema) getCachedCategories(endpoint string, schemaVersion string) (Sch
 		if !ok {
 			return nil, false
 		}
+
 		return cloneCategories(c), true
 	case "domain_categories":
 		c, ok := cached.schemaDomains[schemaVersion]
 		if !ok {
 			return nil, false
 		}
+
 		return cloneCategories(c), true
 	case "module_categories":
 		c, ok := cached.schemaModules[schemaVersion]
 		if !ok {
 			return nil, false
 		}
+
 		return cloneCategories(c), true
 	default:
 		return nil, false
@@ -266,10 +276,12 @@ func (s *Schema) getCachedCategories(endpoint string, schemaVersion string) (Sch
 
 func (s *Schema) fetchCategoriesForVersion(ctx context.Context, version string, endpoint string) (SchemaCategories, error) {
 	categoriesURL := fmt.Sprintf("%s/api/%s/%s", s.schemaURL, version, endpoint)
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, categoriesURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GET request to %s: %w", categoriesURL, err)
 	}
+
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.httpClient.Do(req)
@@ -280,10 +292,12 @@ func (s *Schema) fetchCategoriesForVersion(ctx context.Context, version string, 
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("failed to fetch categories from URL %s: HTTP %d, body: %s", categoriesURL, resp.StatusCode, string(body))
 	}
 
 	var categories SchemaCategories
+
 	decoder := json.NewDecoder(resp.Body)
 	if err := decoder.Decode(&categories); err != nil {
 		return nil, fmt.Errorf("failed to decode categories response from URL %s: %w", categoriesURL, err)
@@ -326,10 +340,12 @@ func (s *Schema) Cache(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to cache skills for version %s: %w", version, err)
 		}
+
 		domains, err := s.fetchCategoriesForVersion(ctx, version, "domain_categories")
 		if err != nil {
 			return fmt.Errorf("failed to cache domains for version %s: %w", version, err)
 		}
+
 		modules, err := s.fetchCategoriesForVersion(ctx, version, "module_categories")
 		if err != nil {
 			return fmt.Errorf("failed to cache modules for version %s: %w", version, err)
@@ -341,6 +357,7 @@ func (s *Schema) Cache(ctx context.Context) error {
 	}
 
 	s.cache.Store(next)
+
 	return nil
 }
 
@@ -374,10 +391,12 @@ func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name stri
 	}
 
 	schemaURL := s.constructSchemaURL(schemaVersion, schemaType, name)
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, schemaURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GET request to %s: %w", schemaURL, err)
 	}
+
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := s.httpClient.Do(req)
@@ -388,6 +407,7 @@ func (s *Schema) GetSchema(ctx context.Context, schemaType SchemaType, name stri
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+
 		return nil, fmt.Errorf("failed to fetch schema from URL %s: HTTP %d, body: %s", schemaURL, resp.StatusCode, string(body))
 	}
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -39,31 +39,31 @@ type VersionInfo struct {
 	APIVersion    string `json:"api_version,omitempty"`
 }
 
-// SchemaCategoryNode represents a nested taxonomy node returned by *_categories endpoints.
-type SchemaCategoryNode struct {
-	ID          int                           `json:"id"`
-	Name        string                        `json:"name"`
-	Description string                        `json:"description,omitempty"`
-	Category    bool                          `json:"category,omitempty"`
-	Caption     string                        `json:"caption,omitempty"`
-	Deprecated  bool                          `json:"deprecated,omitempty"`
-	Classes     map[string]SchemaCategoryNode `json:"classes,omitempty"`
+// TaxonomyItem represents a nested taxonomy node returned by *_categories endpoints.
+type TaxonomyItem struct {
+	ID          int                     `json:"id"`
+	Name        string                  `json:"name"`
+	Description string                  `json:"description,omitempty"`
+	Category    bool                    `json:"category,omitempty"`
+	Caption     string                  `json:"caption,omitempty"`
+	Deprecated  bool                    `json:"deprecated,omitempty"`
+	Classes     map[string]TaxonomyItem `json:"classes,omitempty"`
 }
 
-// SchemaCategories is the top-level category map keyed by category slug.
-type SchemaCategories map[string]SchemaCategoryNode
+// Taxonomy is the top-level category map keyed by category slug.
+type Taxonomy map[string]TaxonomyItem
 
 type schemaCache struct {
 	defaultSchemaVersion    string
 	availableSchemaVersions []string
-	schemaSkills            map[string]SchemaCategories
-	schemaDomains           map[string]SchemaCategories
-	schemaModules           map[string]SchemaCategories
+	skills                  map[string]Taxonomy
+	domains                 map[string]Taxonomy
+	modules                 map[string]Taxonomy
 	jsonSchema              map[string]map[string]jsonSchemaCacheEntry
 }
 
 type jsonSchemaCacheEntry struct {
-	schemaType SchemaType
+	schemaType entityType
 	name       string
 	data       []byte
 }
@@ -74,18 +74,18 @@ type SchemaOption func(*schemaOptions)
 // ConstructorOption is a function that configures schema client behavior.
 type ConstructorOption func(*constructorOptions)
 
-// SchemaType represents the type of schema to fetch.
-type SchemaType string
+// entityType represents the type of schema to fetch.
+type entityType string
 
 const (
-	// SchemaTypeObjects represents object schemas (agent, record).
-	SchemaTypeObjects SchemaType = "objects"
-	// SchemaTypeModules represents module schemas.
-	SchemaTypeModules SchemaType = "modules"
-	// SchemaTypeSkills represents skill schemas.
-	SchemaTypeSkills SchemaType = "skills"
-	// SchemaTypeDomains represents domain schemas.
-	SchemaTypeDomains SchemaType = "domains"
+	// EntityTypeObjects represents object schemas (agent, record).
+	EntityTypeObjects entityType = "objects"
+	// EntityTypeModules represents module schemas.
+	EntityTypeModules entityType = "modules"
+	// EntityTypeSkills represents skill schemas.
+	EntityTypeSkills entityType = "skills"
+	// EntityTypeDomains represents domain schemas.
+	EntityTypeDomains entityType = "domains"
 )
 
 type constructorOptions struct {
@@ -149,23 +149,30 @@ func New(schemaURL string, opts ...ConstructorOption) (*Schema, error) {
 			Timeout: defaultHTTPTimeoutSeconds * time.Second,
 		},
 		cache: &schemaCache{
-			schemaSkills:  map[string]SchemaCategories{},
-			schemaDomains: map[string]SchemaCategories{},
-			schemaModules: map[string]SchemaCategories{},
-			jsonSchema:    map[string]map[string]jsonSchemaCacheEntry{},
+			skills:     map[string]Taxonomy{},
+			domains:    map[string]Taxonomy{},
+			modules:    map[string]Taxonomy{},
+			jsonSchema: map[string]map[string]jsonSchemaCacheEntry{},
 		},
 	}, nil
 }
 
-// cloneCategories deep-copies SchemaCategories before returning it to callers.
-// SchemaCategories is a map type, so returning cached maps directly would expose
+// cloneTaxonomy deep-copies Taxonomy before returning it to callers.
+// Taxonomy is a map type, so returning cached maps directly would expose
 // mutable internal cache state and allow external code to modify it.
-func cloneCategories(src SchemaCategories) SchemaCategories {
-	dst := make(SchemaCategories, len(src))
+func cloneTaxonomy(src Taxonomy) Taxonomy {
+	return cloneTaxonomyItems(map[string]TaxonomyItem(src))
+}
+
+// cloneTaxonomyItems recursively deep-copies a map of TaxonomyItem nodes.
+// Used for both the top-level Taxonomy and nested Classes maps, which share
+// the same underlying type.
+func cloneTaxonomyItems(src map[string]TaxonomyItem) map[string]TaxonomyItem {
+	dst := make(map[string]TaxonomyItem, len(src))
 	for k, v := range src {
 		copied := v
 		if len(v.Classes) > 0 {
-			copied.Classes = cloneCategories(v.Classes)
+			copied.Classes = cloneTaxonomyItems(v.Classes)
 		}
 
 		dst[k] = copied
@@ -321,7 +328,7 @@ func (s *Schema) resolveVersion(ctx context.Context, schemaVersion string) (stri
 	return defaultSchemaVersion, nil
 }
 
-func (s *Schema) getCachedCategories(endpoint string, schemaVersion string) (SchemaCategories, bool) {
+func (s *Schema) getCachedTaxonomy(endpoint string, schemaVersion string) (Taxonomy, bool) {
 	if !s.cacheEnabled {
 		return nil, false
 	}
@@ -331,32 +338,32 @@ func (s *Schema) getCachedCategories(endpoint string, schemaVersion string) (Sch
 
 	switch endpoint {
 	case skillCategoriesEndpoint:
-		c, ok := s.cache.schemaSkills[schemaVersion]
+		c, ok := s.cache.skills[schemaVersion]
 		if !ok {
 			return nil, false
 		}
 
-		return cloneCategories(c), true
+		return cloneTaxonomy(c), true
 	case domainCategoriesEndpoint:
-		c, ok := s.cache.schemaDomains[schemaVersion]
+		c, ok := s.cache.domains[schemaVersion]
 		if !ok {
 			return nil, false
 		}
 
-		return cloneCategories(c), true
+		return cloneTaxonomy(c), true
 	case moduleCategoriesEndpoint:
-		c, ok := s.cache.schemaModules[schemaVersion]
+		c, ok := s.cache.modules[schemaVersion]
 		if !ok {
 			return nil, false
 		}
 
-		return cloneCategories(c), true
+		return cloneTaxonomy(c), true
 	default:
 		return nil, false
 	}
 }
 
-func (s *Schema) setCachedCategories(endpoint string, schemaVersion string, categories SchemaCategories) {
+func (s *Schema) setCachedTaxonomy(endpoint string, schemaVersion string, categories Taxonomy) {
 	if !s.cacheEnabled {
 		return
 	}
@@ -366,19 +373,19 @@ func (s *Schema) setCachedCategories(endpoint string, schemaVersion string, cate
 
 	switch endpoint {
 	case skillCategoriesEndpoint:
-		s.cache.schemaSkills[schemaVersion] = cloneCategories(categories)
+		s.cache.skills[schemaVersion] = cloneTaxonomy(categories)
 	case domainCategoriesEndpoint:
-		s.cache.schemaDomains[schemaVersion] = cloneCategories(categories)
+		s.cache.domains[schemaVersion] = cloneTaxonomy(categories)
 	case moduleCategoriesEndpoint:
-		s.cache.schemaModules[schemaVersion] = cloneCategories(categories)
+		s.cache.modules[schemaVersion] = cloneTaxonomy(categories)
 	}
 }
 
-func jsonSchemaCacheKey(schemaType SchemaType, name string) string {
+func jsonSchemaCacheKey(schemaType entityType, name string) string {
 	return fmt.Sprintf("%s|%s", schemaType, name)
 }
 
-func (s *Schema) getCachedJSONSchema(schemaVersion string, schemaType SchemaType, name string) ([]byte, bool) {
+func (s *Schema) getCachedJSONSchema(schemaVersion string, schemaType entityType, name string) ([]byte, bool) {
 	if !s.cacheEnabled {
 		return nil, false
 	}
@@ -399,7 +406,7 @@ func (s *Schema) getCachedJSONSchema(schemaVersion string, schemaType SchemaType
 	return append([]byte(nil), entry.data...), true
 }
 
-func (s *Schema) setCachedJSONSchema(schemaVersion string, schemaType SchemaType, name string, data []byte) {
+func (s *Schema) setCachedJSONSchema(schemaVersion string, schemaType entityType, name string, data []byte) {
 	if !s.cacheEnabled {
 		return
 	}
@@ -420,7 +427,7 @@ func (s *Schema) setCachedJSONSchema(schemaVersion string, schemaType SchemaType
 	}
 }
 
-func (s *Schema) fetchCategoriesForVersion(ctx context.Context, version string, endpoint string) (SchemaCategories, error) {
+func (s *Schema) fetchTaxonomyForVersion(ctx context.Context, version string, endpoint string) (Taxonomy, error) {
 	categoriesURL := fmt.Sprintf("%s/api/%s/%s", s.schemaURL, version, endpoint)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, categoriesURL, nil)
@@ -442,14 +449,14 @@ func (s *Schema) fetchCategoriesForVersion(ctx context.Context, version string, 
 		return nil, fmt.Errorf("failed to fetch categories from URL %s: HTTP %d, body: %s", categoriesURL, resp.StatusCode, string(body))
 	}
 
-	var categories SchemaCategories
+	var taxonomy Taxonomy
 
 	decoder := json.NewDecoder(resp.Body)
-	if err := decoder.Decode(&categories); err != nil {
+	if err := decoder.Decode(&taxonomy); err != nil {
 		return nil, fmt.Errorf("failed to decode categories response from URL %s: %w", categoriesURL, err)
 	}
 
-	return categories, nil
+	return taxonomy, nil
 }
 
 // ClearCache removes the current cache snapshot.
@@ -460,23 +467,23 @@ func (s *Schema) ClearCache() {
 
 	s.cacheMu.Lock()
 	s.cache = &schemaCache{
-		schemaSkills:  map[string]SchemaCategories{},
-		schemaDomains: map[string]SchemaCategories{},
-		schemaModules: map[string]SchemaCategories{},
-		jsonSchema:    map[string]map[string]jsonSchemaCacheEntry{},
+		skills:     map[string]Taxonomy{},
+		domains:    map[string]Taxonomy{},
+		modules:    map[string]Taxonomy{},
+		jsonSchema: map[string]map[string]jsonSchemaCacheEntry{},
 	}
 	s.cacheMu.Unlock()
 }
 
 // constructSchemaURL builds the schema URL from options.
 // Format: /schema/<version>/<type>/<name>.
-func (s *Schema) constructSchemaURL(version string, schemaType SchemaType, name string) string {
+func (s *Schema) constructSchemaURL(version string, schemaType entityType, name string) string {
 	return fmt.Sprintf("%s/schema/%s/%s/%s", s.schemaURL, version, schemaType, name)
 }
 
 // GetJSONSchema is a generic function to fetch JSON schema content from the OASF API.
 // It constructs the URL as /schema/<version>/<type>/<name>.
-func (s *Schema) GetJSONSchema(ctx context.Context, schemaType SchemaType, name string, opts ...SchemaOption) ([]byte, error) {
+func (s *Schema) GetJSONSchema(ctx context.Context, schemaType entityType, name string, opts ...SchemaOption) ([]byte, error) {
 	options := &schemaOptions{}
 	for _, opt := range opts {
 		opt(options)
@@ -522,8 +529,8 @@ func (s *Schema) GetJSONSchema(ctx context.Context, schemaType SchemaType, name 
 	return schemaData, nil
 }
 
-// GetSchemaCategories fetches nested taxonomy categories from /api/<version>/<endpoint>.
-func (s *Schema) GetSchemaCategories(ctx context.Context, endpoint string, opts ...SchemaOption) (SchemaCategories, error) {
+// GetSchemaTaxonomy fetches nested taxonomy categories from /api/<version>/<endpoint>.
+func (s *Schema) GetSchemaTaxonomy(ctx context.Context, endpoint string, opts ...SchemaOption) (Taxonomy, error) {
 	options := &schemaOptions{}
 	for _, opt := range opts {
 		opt(options)
@@ -534,36 +541,36 @@ func (s *Schema) GetSchemaCategories(ctx context.Context, endpoint string, opts 
 		return nil, err
 	}
 
-	if categories, ok := s.getCachedCategories(endpoint, version); ok {
+	if categories, ok := s.getCachedTaxonomy(endpoint, version); ok {
 		return categories, nil
 	}
 
-	categories, err := s.fetchCategoriesForVersion(ctx, version, endpoint)
+	categories, err := s.fetchTaxonomyForVersion(ctx, version, endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	s.setCachedCategories(endpoint, version, categories)
+	s.setCachedTaxonomy(endpoint, version, categories)
 
 	return categories, nil
 }
 
 // GetRecordJSONSchema returns the record JSON schema content for a given version.
 func (s *Schema) GetRecordJSONSchema(ctx context.Context, opts ...SchemaOption) ([]byte, error) {
-	return s.GetJSONSchema(ctx, SchemaTypeObjects, "record", opts...)
+	return s.GetJSONSchema(ctx, EntityTypeObjects, "record", opts...)
 }
 
 // GetSchemaSkills returns nested skill categories from /api/<version>/skill_categories.
-func (s *Schema) GetSchemaSkills(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
-	return s.GetSchemaCategories(ctx, skillCategoriesEndpoint, opts...)
+func (s *Schema) GetSchemaSkills(ctx context.Context, opts ...SchemaOption) (Taxonomy, error) {
+	return s.GetSchemaTaxonomy(ctx, skillCategoriesEndpoint, opts...)
 }
 
 // GetSchemaDomains returns nested domain categories from /api/<version>/domain_categories.
-func (s *Schema) GetSchemaDomains(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
-	return s.GetSchemaCategories(ctx, domainCategoriesEndpoint, opts...)
+func (s *Schema) GetSchemaDomains(ctx context.Context, opts ...SchemaOption) (Taxonomy, error) {
+	return s.GetSchemaTaxonomy(ctx, domainCategoriesEndpoint, opts...)
 }
 
 // GetSchemaModules returns nested module categories from /api/<version>/module_categories.
-func (s *Schema) GetSchemaModules(ctx context.Context, opts ...SchemaOption) (SchemaCategories, error) {
-	return s.GetSchemaCategories(ctx, moduleCategoriesEndpoint, opts...)
+func (s *Schema) GetSchemaModules(ctx context.Context, opts ...SchemaOption) (Taxonomy, error) {
+	return s.GetSchemaTaxonomy(ctx, moduleCategoriesEndpoint, opts...)
 }

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -56,6 +56,41 @@ func mockSchemaResponse() map[string]any {
 	}
 }
 
+func mockCategoriesResponse() SchemaCategories {
+	return SchemaCategories{
+		"core": {
+			ID:          1,
+			Name:        "core",
+			Description: "Module set for core functionalities and features.",
+			Category:    true,
+			Caption:     "Core",
+			Classes: map[string]SchemaCategoryNode{
+				"language_model": {
+					ID:          103,
+					Name:        "core/language_model",
+					Description: "Modules for basic Language Model functionality.",
+					Caption:     "Language Model",
+					Classes: map[string]SchemaCategoryNode{
+						"prompt": {
+							ID:          10301,
+							Name:        "core/language_model/prompt",
+							Description: "Describes common Language Model interaction prompts to use the agent.",
+							Caption:     "Language Model Prompt",
+						},
+					},
+				},
+			},
+		},
+		"integration": {
+			ID:          2,
+			Name:        "integration",
+			Description: "Module set for integrating with external systems and services.",
+			Category:    true,
+			Caption:     "Integration",
+		},
+	}
+}
+
 // createMockServer creates a mock HTTP server for schema tests.
 func createMockServer(t *testing.T, version string, expectError bool) *httptest.Server {
 	t.Helper()
@@ -295,8 +330,21 @@ func createMockServerWithVersionCheck(t *testing.T, checkVersion bool) *httptest
 			return
 		}
 
-		// Validate schema request shape.
+		// Handle category endpoints.
 		pathParts := strings.Split(r.URL.Path, "/")
+		if len(pathParts) == 4 && pathParts[1] == "api" &&
+			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			if err := json.NewEncoder(w).Encode(mockCategoriesResponse()); err != nil {
+				t.Errorf("Failed to encode categories response: %v", err)
+			}
+
+			return
+		}
+
+		// Validate schema request shape.
+		pathParts = strings.Split(r.URL.Path, "/")
 		if len(pathParts) < 5 || pathParts[1] != "schema" {
 			t.Errorf("Expected path /schema/<version>/<type>/<name>, got %s", r.URL.Path)
 		}
@@ -311,116 +359,21 @@ func createMockServerWithVersionCheck(t *testing.T, checkVersion bool) *httptest
 	}))
 }
 
-// validateSchemaKeyResult validates the result from GetSchemaKey.
-func validateSchemaKeyResult(t *testing.T, result []byte, expectEmpty bool) {
-	t.Helper()
-
-	if expectEmpty {
-		if len(result) > 2 { // More than just {}
-			t.Errorf("GetSchemaKey() expected empty result but got data")
-		}
-
-		return
-	}
-
-	if len(result) == 0 {
-		t.Errorf("GetSchemaKey() returned empty result")
-	}
-
-	var jsonMap map[string]any
-	if err := json.Unmarshal(result, &jsonMap); err != nil {
-		t.Errorf("GetSchemaKey() returned invalid JSON: %v", err)
-	}
-}
-
-func TestGetSchemaKey(t *testing.T) {
-	tests := []struct {
-		name        string
-		version     string
-		defsKey     string
-		expectError bool
-		expectEmpty bool
-	}{
-		{
-			name:        "valid skills key",
-			version:     "0.7.0",
-			defsKey:     "skills",
-			expectError: false,
-			expectEmpty: false,
-		},
-		{
-			name:        "valid domains key",
-			version:     "0.7.0",
-			defsKey:     "domains",
-			expectError: false,
-			expectEmpty: false,
-		},
-		{
-			name:        "valid objects key",
-			version:     "0.7.0",
-			defsKey:     "objects",
-			expectError: false,
-			expectEmpty: false,
-		},
-		{
-			name:        "invalid key",
-			version:     "0.7.0",
-			defsKey:     "nonexistent",
-			expectError: true,
-		},
-		{
-			name:        "invalid version",
-			version:     invalidVersion,
-			defsKey:     "skills",
-			expectError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := createMockServerWithVersionCheck(t, tt.expectError && tt.version == invalidVersion)
-			defer server.Close()
-
-			schema, err := New(server.URL)
-			if err != nil {
-				t.Fatalf("Failed to create schema: %v", err)
-			}
-
-			result, err := schema.GetSchemaKey(context.Background(), tt.defsKey, WithVersion(tt.version))
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("GetSchemaKey() expected error but got none")
-				}
-
-				return
-			}
-
-			if err != nil {
-				t.Errorf("GetSchemaKey() unexpected error: %v", err)
-
-				return
-			}
-
-			validateSchemaKeyResult(t, result, tt.expectEmpty)
-		})
-	}
-}
-
 // validateSkillsResult validates the result from GetSchemaSkills.
-func validateSkillsResult(t *testing.T, skills []byte) {
+func validateSkillsResult(t *testing.T, skills SchemaCategories) {
 	t.Helper()
 
 	if len(skills) == 0 {
-		t.Errorf("GetSchemaSkills() returned empty skills")
-	}
-
-	var skillsMap map[string]any
-	if err := json.Unmarshal(skills, &skillsMap); err != nil {
-		t.Errorf("GetSchemaSkills() returned invalid JSON: %v", err)
-	}
-
-	if len(skillsMap) == 0 {
 		t.Errorf("GetSchemaSkills() returned empty skills map")
+	}
+
+	core, ok := skills["core"]
+	if !ok {
+		t.Fatalf("GetSchemaSkills() missing top-level 'core' category")
+	}
+
+	if _, ok := core.Classes["language_model"]; !ok {
+		t.Errorf("GetSchemaSkills() missing nested 'language_model' class")
 	}
 }
 
@@ -482,21 +435,16 @@ func TestGetSchemaSkills(t *testing.T) {
 }
 
 // validateDomainsResult validates the result from GetSchemaDomains.
-func validateDomainsResult(t *testing.T, domains []byte, version string) {
+func validateDomainsResult(t *testing.T, domains SchemaCategories, version string) {
 	t.Helper()
 
-	var domainsMap map[string]any
-	if err := json.Unmarshal(domains, &domainsMap); err != nil {
-		t.Errorf("GetSchemaDomains() returned invalid JSON: %v", err)
-	}
-
 	if version == testSchemaVersion {
-		if len(domainsMap) == 0 {
+		if len(domains) == 0 {
 			t.Errorf("GetSchemaDomains() returned empty domains map for version %s", version)
 		}
 
-		if _, ok := domainsMap["lean_manufacturing"]; !ok {
-			t.Logf("Warning: Expected domain 'lean_manufacturing' not found in version %s", version)
+		if _, ok := domains["core"]; !ok {
+			t.Logf("Warning: Expected domain category 'core' not found in version %s", version)
 		}
 	}
 }
@@ -582,6 +530,18 @@ func createMockServerWithVersionsEndpoint(t *testing.T) *httptest.Server {
 
 			if err := json.NewEncoder(w).Encode(versionsResp); err != nil {
 				t.Errorf("Failed to encode versions response: %v", err)
+			}
+
+			return
+		}
+
+		pathParts := strings.Split(r.URL.Path, "/")
+		if len(pathParts) == 4 && pathParts[1] == "api" &&
+			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			if err := json.NewEncoder(w).Encode(mockCategoriesResponse()); err != nil {
+				t.Errorf("Failed to encode categories response: %v", err)
 			}
 
 			return
@@ -731,49 +691,30 @@ func TestGetDefaultSchemaVersionLegacyFormat(t *testing.T) {
 	}
 }
 
-// Helper function to compare schema section counts between dedicated getter and full schema.
-func compareSchemaSection(t *testing.T, schema *Schema, version string, sectionName string, getSection func(context.Context, ...SchemaOption) ([]byte, error)) {
+// validateCategoryTree checks that categories include nested classes.
+func validateCategoryTree(t *testing.T, categories SchemaCategories) {
 	t.Helper()
 
-	fullSchema, err := schema.GetRecordSchemaContent(context.Background(), WithVersion(version))
-	if err != nil {
-		t.Fatalf("Failed to get full schema: %v", err)
+	if len(categories) == 0 {
+		t.Fatalf("Expected non-empty category response")
 	}
 
-	var fullSchemaMap map[string]any
-	if err := json.Unmarshal(fullSchema, &fullSchemaMap); err != nil {
-		t.Fatalf("Failed to parse full schema: %v", err)
-	}
-
-	sectionData, err := getSection(context.Background(), WithVersion(version))
-	if err != nil {
-		t.Fatalf("Failed to get %s: %v", sectionName, err)
-	}
-
-	var sectionMap map[string]any
-	if err := json.Unmarshal(sectionData, &sectionMap); err != nil {
-		t.Fatalf("Failed to parse %s: %v", sectionName, err)
-	}
-
-	// Extract section from full schema
-	defs, ok := fullSchemaMap["$defs"].(map[string]any)
+	core, ok := categories["core"]
 	if !ok {
-		t.Fatalf("Expected $defs to be map[string]any")
+		t.Fatalf("Expected top-level 'core' category")
 	}
 
-	fullSchemaSection, ok := defs[sectionName].(map[string]any)
+	languageModel, ok := core.Classes["language_model"]
 	if !ok {
-		t.Fatalf("Expected %s to be map[string]any", sectionName)
+		t.Fatalf("Expected nested 'language_model' class")
 	}
 
-	// Compare the number of items
-	if len(sectionMap) != len(fullSchemaSection) {
-		t.Errorf("%s count mismatch: getter returned %d items, full schema has %d items",
-			sectionName, len(sectionMap), len(fullSchemaSection))
+	if _, ok := languageModel.Classes["prompt"]; !ok {
+		t.Fatalf("Expected nested 'prompt' class")
 	}
 }
 
-func TestGetSchemaSkillsVsFullSchema(t *testing.T) {
+func TestGetSchemaSkillsNested(t *testing.T) {
 	// Create a mock HTTP server
 	server := createMockServerWithVersionsEndpoint(t)
 	defer server.Close()
@@ -784,12 +725,15 @@ func TestGetSchemaSkillsVsFullSchema(t *testing.T) {
 		t.Fatalf("Failed to create schema: %v", err)
 	}
 
-	// This test ensures that GetSchemaSkills returns the same skills
-	// section as in the full schema
-	compareSchemaSection(t, schema, testSchemaVersion, "skills", schema.GetSchemaSkills)
+	skills, err := schema.GetSchemaSkills(context.Background(), WithVersion(testSchemaVersion))
+	if err != nil {
+		t.Fatalf("Failed to get skills: %v", err)
+	}
+
+	validateCategoryTree(t, skills)
 }
 
-func TestGetSchemaDomainsVsFullSchema(t *testing.T) {
+func TestGetSchemaDomainsNested(t *testing.T) {
 	// Create a mock HTTP server
 	server := createMockServerWithVersionsEndpoint(t)
 	defer server.Close()
@@ -800,9 +744,12 @@ func TestGetSchemaDomainsVsFullSchema(t *testing.T) {
 		t.Fatalf("Failed to create schema: %v", err)
 	}
 
-	// This test ensures that GetSchemaDomains returns the same domains
-	// section as in the full schema
-	compareSchemaSection(t, schema, testSchemaVersion, "domains", schema.GetSchemaDomains)
+	domains, err := schema.GetSchemaDomains(context.Background(), WithVersion(testSchemaVersion))
+	if err != nil {
+		t.Fatalf("Failed to get domains: %v", err)
+	}
+
+	validateCategoryTree(t, domains)
 }
 
 func TestGetSchemaModules(t *testing.T) {
@@ -859,6 +806,24 @@ func TestDefaultVersion(t *testing.T) {
 			requestedVersions = append(requestedVersions, pathParts[2])
 		}
 
+		// Track which schema version was requested on /api/<version>/*_categories.
+		if len(pathParts) == 4 && pathParts[1] == "api" &&
+			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+			requestedVersions = append(requestedVersions, pathParts[2])
+		}
+
+		// Return category responses for category endpoints.
+		if len(pathParts) == 4 && pathParts[1] == "api" &&
+			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			if err := json.NewEncoder(w).Encode(mockCategoriesResponse()); err != nil {
+				t.Errorf("Failed to encode categories response: %v", err)
+			}
+
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
@@ -905,15 +870,6 @@ func TestDefaultVersion(t *testing.T) {
 				return err
 			},
 			minCount: 3,
-		},
-		{
-			name: "GetSchemaKey",
-			testFunc: func() error {
-				_, err := schema.GetSchemaKey(context.Background(), "skills")
-
-				return err
-			},
-			minCount: 4,
 		},
 	}
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -64,21 +64,21 @@ func mockSchemaResponse() map[string]any {
 	}
 }
 
-func mockCategoriesResponse() SchemaCategories {
-	return SchemaCategories{
+func mockCategoriesResponse() Taxonomy {
+	return Taxonomy{
 		"core": {
 			ID:          1,
 			Name:        "core",
 			Description: "Module set for core functionalities and features.",
 			Category:    true,
 			Caption:     "Core",
-			Classes: map[string]SchemaCategoryNode{
+			Classes: map[string]TaxonomyItem{
 				"language_model": {
 					ID:          103,
 					Name:        "core/language_model",
 					Description: "Modules for basic Language Model functionality.",
 					Caption:     "Language Model",
-					Classes: map[string]SchemaCategoryNode{
+					Classes: map[string]TaxonomyItem{
 						"prompt": {
 							ID:          10301,
 							Name:        "core/language_model/prompt",
@@ -227,42 +227,42 @@ func TestGetJSONSchema(t *testing.T) {
 	tests := []struct {
 		name        string
 		version     string
-		typ         SchemaType
+		typ         entityType
 		schemaName  string
 		expectError bool
 	}{
 		{
 			name:        "valid objects/record for 0.8.0",
 			version:     "0.8.0",
-			typ:         SchemaTypeObjects,
+			typ:         EntityTypeObjects,
 			schemaName:  "record",
 			expectError: false,
 		},
 		{
 			name:        "valid modules",
 			version:     "0.8.0",
-			typ:         SchemaTypeModules,
+			typ:         EntityTypeModules,
 			schemaName:  "integration/mcp",
 			expectError: false,
 		},
 		{
 			name:        "valid skills",
 			version:     "0.8.0",
-			typ:         SchemaTypeSkills,
+			typ:         EntityTypeSkills,
 			schemaName:  "natural_language_processing",
 			expectError: false,
 		},
 		{
 			name:        "valid domains",
 			version:     "0.8.0",
-			typ:         SchemaTypeDomains,
+			typ:         EntityTypeDomains,
 			schemaName:  "artificial_intelligence",
 			expectError: false,
 		},
 		{
 			name:        "invalid version",
 			version:     invalidVersion,
-			typ:         SchemaTypeObjects,
+			typ:         EntityTypeObjects,
 			schemaName:  "record",
 			expectError: true,
 		},
@@ -369,7 +369,7 @@ func createMockServerWithVersionCheck(t *testing.T, checkVersion bool) *httptest
 }
 
 // validateSkillsResult validates the result from GetSchemaSkills.
-func validateSkillsResult(t *testing.T, skills SchemaCategories) {
+func validateSkillsResult(t *testing.T, skills Taxonomy) {
 	t.Helper()
 
 	if len(skills) == 0 {
@@ -444,7 +444,7 @@ func TestGetSchemaSkills(t *testing.T) {
 }
 
 // validateDomainsResult validates the result from GetSchemaDomains.
-func validateDomainsResult(t *testing.T, domains SchemaCategories, version string) {
+func validateDomainsResult(t *testing.T, domains Taxonomy, version string) {
 	t.Helper()
 
 	if version == testSchemaVersion {
@@ -674,7 +674,7 @@ func TestGetDefaultSchemaVersion(t *testing.T) {
 }
 
 // validateCategoryTree checks that categories include nested classes.
-func validateCategoryTree(t *testing.T, categories SchemaCategories) {
+func validateCategoryTree(t *testing.T, categories Taxonomy) {
 	t.Helper()
 
 	if len(categories) == 0 {

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -1002,6 +1002,155 @@ func TestSchemaCategoriesCachedByVersion(t *testing.T) {
 	}
 }
 
+func TestClearCache(t *testing.T) {
+	var versionsCalls int32
+	var skillCalls int32
+	var domainCalls int32
+	var moduleCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case apiVersionsPath:
+			atomic.AddInt32(&versionsCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(VersionsResponse{
+				Default: VersionInfo{SchemaVersion: "0.8.0"},
+				Versions: []VersionInfo{
+					{SchemaVersion: "0.8.0"},
+				},
+			})
+			return
+		case "/api/0.8.0/skill_categories":
+			atomic.AddInt32(&skillCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+			return
+		case "/api/0.8.0/domain_categories":
+			atomic.AddInt32(&domainCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+			return
+		case "/api/0.8.0/module_categories":
+			atomic.AddInt32(&moduleCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	s, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	if err := s.Cache(context.Background()); err != nil {
+		t.Fatalf("Cache failed: %v", err)
+	}
+	if _, err := s.GetSchemaSkills(context.Background(), WithVersion("0.8.0")); err != nil {
+		t.Fatalf("GetSchemaSkills from cache failed: %v", err)
+	}
+
+	s.ClearCache()
+
+	if _, err := s.GetSchemaSkills(context.Background(), WithVersion("0.8.0")); err != nil {
+		t.Fatalf("GetSchemaSkills after ClearCache failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&versionsCalls); got != 2 {
+		t.Fatalf("expected two /api/versions calls, got %d", got)
+	}
+	if got := atomic.LoadInt32(&skillCalls); got != 2 {
+		t.Fatalf("expected two skill fetches, got %d", got)
+	}
+	if got := atomic.LoadInt32(&domainCalls); got != 1 {
+		t.Fatalf("expected one domain fetch from initial Cache, got %d", got)
+	}
+	if got := atomic.LoadInt32(&moduleCalls); got != 1 {
+		t.Fatalf("expected one module fetch from initial Cache, got %d", got)
+	}
+}
+
+func TestReloadCache(t *testing.T) {
+	var skillCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case apiVersionsPath:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(VersionsResponse{
+				Default: VersionInfo{SchemaVersion: "0.8.0"},
+				Versions: []VersionInfo{
+					{SchemaVersion: "0.8.0"},
+				},
+			})
+			return
+		case "/api/0.8.0/skill_categories":
+			call := atomic.AddInt32(&skillCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			if call == 1 {
+				_ = json.NewEncoder(w).Encode(SchemaCategories{
+					"skills": {ID: 1, Name: "skills-v1"},
+				})
+			} else {
+				_ = json.NewEncoder(w).Encode(SchemaCategories{
+					"skills": {ID: 1, Name: "skills-v2"},
+				})
+			}
+			return
+		case "/api/0.8.0/domain_categories", "/api/0.8.0/module_categories":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	s, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	if err := s.Cache(context.Background()); err != nil {
+		t.Fatalf("Cache failed: %v", err)
+	}
+	first, err := s.GetSchemaSkills(context.Background(), WithVersion("0.8.0"))
+	if err != nil {
+		t.Fatalf("GetSchemaSkills first cached read failed: %v", err)
+	}
+	if first["skills"].Name != "skills-v1" {
+		t.Fatalf("expected first cached value skills-v1, got %q", first["skills"].Name)
+	}
+
+	if err := s.ReloadCache(context.Background()); err != nil {
+		t.Fatalf("ReloadCache failed: %v", err)
+	}
+	second, err := s.GetSchemaSkills(context.Background(), WithVersion("0.8.0"))
+	if err != nil {
+		t.Fatalf("GetSchemaSkills second cached read failed: %v", err)
+	}
+	if second["skills"].Name != "skills-v2" {
+		t.Fatalf("expected reloaded cached value skills-v2, got %q", second["skills"].Name)
+	}
+
+	if got := atomic.LoadInt32(&skillCalls); got != 2 {
+		t.Fatalf("expected two skill endpoint calls (cache + reload), got %d", got)
+	}
+}
+
 func TestGetSchemaModulesRejectsUnsupportedVersionBeforeCategoryFetch(t *testing.T) {
 	categoryEndpointHit := false
 	versionsEndpointCalls := 0

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -17,6 +17,16 @@ const testSchemaVersion = "0.7.0"
 
 const invalidVersion = "99.99.99"
 
+const (
+	apiPathSegment           = "api"
+	skillCategoriesEndpoint  = "skill_categories"
+	domainCategoriesEndpoint = "domain_categories"
+	moduleCategoriesEndpoint = "module_categories"
+	pathSkillCategories080   = "/api/0.8.0/skill_categories"
+	pathDomainCategories080  = "/api/0.8.0/domain_categories"
+	pathModuleCategories080  = "/api/0.8.0/module_categories"
+)
+
 // mockSchemaResponse returns a mock schema JSON response with $defs section.
 func mockSchemaResponse() map[string]any {
 	return map[string]any{
@@ -333,10 +343,11 @@ func createMockServerWithVersionCheck(t *testing.T, checkVersion bool) *httptest
 
 		// Handle category endpoints.
 		pathParts := strings.Split(r.URL.Path, "/")
-		if len(pathParts) == 4 && pathParts[1] == "api" &&
-			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+		if len(pathParts) == 4 && pathParts[1] == apiPathSegment &&
+			(pathParts[3] == moduleCategoriesEndpoint || pathParts[3] == skillCategoriesEndpoint || pathParts[3] == domainCategoriesEndpoint) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+
 			if err := json.NewEncoder(w).Encode(mockCategoriesResponse()); err != nil {
 				t.Errorf("Failed to encode categories response: %v", err)
 			}
@@ -537,10 +548,11 @@ func createMockServerWithVersionsEndpoint(t *testing.T) *httptest.Server {
 		}
 
 		pathParts := strings.Split(r.URL.Path, "/")
-		if len(pathParts) == 4 && pathParts[1] == "api" &&
-			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+		if len(pathParts) == 4 && pathParts[1] == apiPathSegment &&
+			(pathParts[3] == moduleCategoriesEndpoint || pathParts[3] == skillCategoriesEndpoint || pathParts[3] == domainCategoriesEndpoint) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+
 			if err := json.NewEncoder(w).Encode(mockCategoriesResponse()); err != nil {
 				t.Errorf("Failed to encode categories response: %v", err)
 			}
@@ -614,6 +626,7 @@ func TestGetAvailableSchemaVersions(t *testing.T) {
 			{SchemaVersion: "1.0.0", URL: "http://schema.oasf.outshift.com:8000/1.0.0/api"},
 		},
 	}
+
 	t.Run("valid versions response", func(t *testing.T) {
 		server := createVersionsMockServer(t, mockResponse)
 		defer server.Close()
@@ -742,6 +755,7 @@ func TestGetSchemaModules(t *testing.T) {
 	_ = err
 }
 
+//nolint:cyclop // Table-driven split would reduce complexity but hurt readability here.
 func TestDefaultVersion(t *testing.T) {
 	defaultVersion := "0.8.0"
 
@@ -779,16 +793,17 @@ func TestDefaultVersion(t *testing.T) {
 		}
 
 		// Track which schema version was requested on /api/<version>/*_categories.
-		if len(pathParts) == 4 && pathParts[1] == "api" &&
-			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+		if len(pathParts) == 4 && pathParts[1] == apiPathSegment &&
+			(pathParts[3] == moduleCategoriesEndpoint || pathParts[3] == skillCategoriesEndpoint || pathParts[3] == domainCategoriesEndpoint) {
 			requestedVersions = append(requestedVersions, pathParts[2])
 		}
 
 		// Return category responses for category endpoints.
-		if len(pathParts) == 4 && pathParts[1] == "api" &&
-			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+		if len(pathParts) == 4 && pathParts[1] == apiPathSegment &&
+			(pathParts[3] == moduleCategoriesEndpoint || pathParts[3] == skillCategoriesEndpoint || pathParts[3] == domainCategoriesEndpoint) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+
 			if err := json.NewEncoder(w).Encode(mockCategoriesResponse()); err != nil {
 				t.Errorf("Failed to encode categories response: %v", err)
 			}
@@ -885,6 +900,7 @@ func TestVersionsAreCached(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
 			return
 		}
 
@@ -900,12 +916,15 @@ func TestVersionsAreCached(t *testing.T) {
 	if err := s.Cache(context.Background()); err != nil {
 		t.Fatalf("Cache failed: %v", err)
 	}
+
 	if _, err := s.GetAvailableSchemaVersions(context.Background()); err != nil {
 		t.Fatalf("GetAvailableSchemaVersions from cache failed: %v", err)
 	}
+
 	if _, err := s.GetDefaultSchemaVersion(context.Background()); err != nil {
 		t.Fatalf("GetDefaultSchemaVersion from cache failed: %v", err)
 	}
+
 	if _, err := s.GetAvailableSchemaVersions(context.Background()); err != nil {
 		t.Fatalf("GetAvailableSchemaVersions second cached call failed: %v", err)
 	}
@@ -929,25 +948,30 @@ func TestSchemaCategoriesCachedByVersion(t *testing.T) {
 					{SchemaVersion: "0.8.0"},
 				},
 			})
+
 			return
-		case "/api/0.8.0/skill_categories":
+		case pathSkillCategories080:
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
 			return
-		case "/api/0.8.0/domain_categories":
+		case pathDomainCategories080:
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
 			return
-		case "/api/0.8.0/module_categories":
+		case pathModuleCategories080:
 			atomic.AddInt32(&categoryCalls, 1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
 			return
 		default:
 			w.WriteHeader(http.StatusNotFound)
+
 			return
 		}
 	}))
@@ -961,9 +985,11 @@ func TestSchemaCategoriesCachedByVersion(t *testing.T) {
 	if err := s.Cache(context.Background()); err != nil {
 		t.Fatalf("Cache failed: %v", err)
 	}
+
 	if _, err := s.GetSchemaModules(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
 		t.Fatalf("GetSchemaModules first cached call failed: %v", err)
 	}
+
 	if _, err := s.GetSchemaModules(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
 		t.Fatalf("GetSchemaModules second cached call failed: %v", err)
 	}
@@ -974,10 +1000,12 @@ func TestSchemaCategoriesCachedByVersion(t *testing.T) {
 }
 
 func TestClearCache(t *testing.T) {
-	var versionsCalls int32
-	var skillCalls int32
-	var domainCalls int32
-	var moduleCalls int32
+	var (
+		versionsCalls int32
+		skillCalls    int32
+		domainCalls   int32
+		moduleCalls   int32
+	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -991,27 +1019,32 @@ func TestClearCache(t *testing.T) {
 					{SchemaVersion: "0.8.0"},
 				},
 			})
+
 			return
 		case "/api/0.8.0/skill_categories":
 			atomic.AddInt32(&skillCalls, 1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
 			return
 		case "/api/0.8.0/domain_categories":
 			atomic.AddInt32(&domainCalls, 1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
 			return
 		case "/api/0.8.0/module_categories":
 			atomic.AddInt32(&moduleCalls, 1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
 			return
 		default:
 			w.WriteHeader(http.StatusNotFound)
+
 			return
 		}
 	}))
@@ -1025,6 +1058,7 @@ func TestClearCache(t *testing.T) {
 	if err := s.Cache(context.Background()); err != nil {
 		t.Fatalf("Cache failed: %v", err)
 	}
+
 	if _, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
 		t.Fatalf("GetSchemaSkills from cache failed: %v", err)
 	}
@@ -1038,12 +1072,15 @@ func TestClearCache(t *testing.T) {
 	if got := atomic.LoadInt32(&versionsCalls); got != 2 {
 		t.Fatalf("expected two /api/versions calls, got %d", got)
 	}
+
 	if got := atomic.LoadInt32(&skillCalls); got != 2 {
 		t.Fatalf("expected two skill fetches, got %d", got)
 	}
+
 	if got := atomic.LoadInt32(&domainCalls); got != 1 {
 		t.Fatalf("expected one domain fetch from initial Cache, got %d", got)
 	}
+
 	if got := atomic.LoadInt32(&moduleCalls); got != 1 {
 		t.Fatalf("expected one module fetch from initial Cache, got %d", got)
 	}
@@ -1063,11 +1100,14 @@ func TestReloadCache(t *testing.T) {
 					{SchemaVersion: "0.8.0"},
 				},
 			})
+
 			return
 		case "/api/0.8.0/skill_categories":
 			call := atomic.AddInt32(&skillCalls, 1)
+
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
+
 			if call == 1 {
 				_ = json.NewEncoder(w).Encode(SchemaCategories{
 					"skills": {ID: 1, Name: "skills-v1"},
@@ -1077,14 +1117,17 @@ func TestReloadCache(t *testing.T) {
 					"skills": {ID: 1, Name: "skills-v2"},
 				})
 			}
+
 			return
 		case "/api/0.8.0/domain_categories", "/api/0.8.0/module_categories":
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
 			return
 		default:
 			w.WriteHeader(http.StatusNotFound)
+
 			return
 		}
 	}))
@@ -1098,10 +1141,12 @@ func TestReloadCache(t *testing.T) {
 	if err := s.Cache(context.Background()); err != nil {
 		t.Fatalf("Cache failed: %v", err)
 	}
+
 	first, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0"))
 	if err != nil {
 		t.Fatalf("GetSchemaSkills first cached read failed: %v", err)
 	}
+
 	if first["skills"].Name != "skills-v1" {
 		t.Fatalf("expected first cached value skills-v1, got %q", first["skills"].Name)
 	}
@@ -1109,10 +1154,12 @@ func TestReloadCache(t *testing.T) {
 	if err := s.ReloadCache(context.Background()); err != nil {
 		t.Fatalf("ReloadCache failed: %v", err)
 	}
+
 	second, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0"))
 	if err != nil {
 		t.Fatalf("GetSchemaSkills second cached read failed: %v", err)
 	}
+
 	if second["skills"].Name != "skills-v2" {
 		t.Fatalf("expected reloaded cached value skills-v2, got %q", second["skills"].Name)
 	}
@@ -1129,6 +1176,7 @@ func TestGetSchemaModulesRejectsUnsupportedVersionBeforeCategoryFetch(t *testing
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == apiVersionsPath {
 			versionsEndpointCalls++
+
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(VersionsResponse{
@@ -1144,6 +1192,7 @@ func TestGetSchemaModulesRejectsUnsupportedVersionBeforeCategoryFetch(t *testing
 
 		if strings.HasPrefix(r.URL.Path, "/api/") && strings.HasSuffix(r.URL.Path, "/module_categories") {
 			categoryEndpointHit = true
+
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
@@ -1164,12 +1213,15 @@ func TestGetSchemaModulesRejectsUnsupportedVersionBeforeCategoryFetch(t *testing
 	if err == nil {
 		t.Fatalf("Expected unsupported-version error, got nil")
 	}
+
 	if !strings.Contains(err.Error(), `schema version "1.1.0" is not supported`) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
+
 	if categoryEndpointHit {
 		t.Fatalf("Category endpoint should not be called for unsupported version")
 	}
+
 	if versionsEndpointCalls != 1 {
 		t.Fatalf("Expected one versions fetch, got %d", versionsEndpointCalls)
 	}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -198,7 +198,7 @@ func TestGetRecordSchemaContent(t *testing.T) {
 				t.Fatalf("Failed to create schema: %v", err)
 			}
 
-			content, err := schema.GetRecordSchemaContent(context.Background(), WithVersion(tt.version))
+			content, err := schema.GetRecordSchemaContent(context.Background(), WithSchemaVersion(tt.version))
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("GetRecordSchemaContent() expected error but got none")
@@ -274,7 +274,7 @@ func TestGetSchema(t *testing.T) {
 			var opts []SchemaOption
 
 			if tt.version != "" {
-				opts = append(opts, WithVersion(tt.version))
+				opts = append(opts, WithSchemaVersion(tt.version))
 			}
 
 			content, err := schema.GetSchema(context.Background(), tt.typ, tt.schemaName, opts...)
@@ -417,7 +417,7 @@ func TestGetSchemaSkills(t *testing.T) {
 				t.Fatalf("Failed to create schema: %v", err)
 			}
 
-			skills, err := schema.GetSchemaSkills(context.Background(), WithVersion(tt.version))
+			skills, err := schema.GetSchemaSkills(context.Background(), WithSchemaVersion(tt.version))
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("GetSchemaSkills() expected error but got none")
@@ -489,7 +489,7 @@ func TestGetSchemaDomains(t *testing.T) {
 				t.Fatalf("Failed to create schema: %v", err)
 			}
 
-			domains, err := schema.GetSchemaDomains(context.Background(), WithVersion(tt.version))
+			domains, err := schema.GetSchemaDomains(context.Background(), WithSchemaVersion(tt.version))
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("GetSchemaDomains() expected error but got none")
@@ -614,18 +614,6 @@ func TestGetAvailableSchemaVersions(t *testing.T) {
 			{SchemaVersion: "1.0.0", URL: "http://schema.oasf.outshift.com:8000/1.0.0/api"},
 		},
 	}
-	legacyMockResponse := VersionsResponse{
-		Default: VersionInfo{
-			Version: "0.8.0",
-			URL:     "http://schema.oasf.outshift.com:8000/api/0.8.0",
-		},
-		Versions: []VersionInfo{
-			{Version: "0.7.0", URL: "http://schema.oasf.outshift.com:8000/0.7.0/api"},
-			{Version: "0.8.0", URL: "http://schema.oasf.outshift.com:8000/0.8.0/api"},
-			{Version: "1.0.0", URL: "http://schema.oasf.outshift.com:8000/1.0.0/api"},
-		},
-	}
-
 	t.Run("valid versions response", func(t *testing.T) {
 		server := createVersionsMockServer(t, mockResponse)
 		defer server.Close()
@@ -642,23 +630,6 @@ func TestGetAvailableSchemaVersions(t *testing.T) {
 
 		validateVersionsResult(t, versions)
 	})
-	t.Run("legacy versions response", func(t *testing.T) {
-		server := createVersionsMockServer(t, legacyMockResponse)
-		defer server.Close()
-
-		schema, err := New(server.URL)
-		if err != nil {
-			t.Fatalf("Failed to create schema: %v", err)
-		}
-
-		versions, err := schema.GetAvailableSchemaVersions(context.Background())
-		if err != nil {
-			t.Errorf("GetAvailableSchemaVersions() unexpected error: %v", err)
-		}
-
-		validateVersionsResult(t, versions)
-	})
-
 	t.Run("empty URL", func(t *testing.T) {
 		_, err := New("")
 		if err == nil {
@@ -667,12 +638,12 @@ func TestGetAvailableSchemaVersions(t *testing.T) {
 	})
 }
 
-func TestGetDefaultSchemaVersionLegacyFormat(t *testing.T) {
+func TestGetDefaultSchemaVersion(t *testing.T) {
 	server := createVersionsMockServer(t, VersionsResponse{
-		Default: VersionInfo{Version: "0.8.0"},
+		Default: VersionInfo{SchemaVersion: "0.8.0"},
 		Versions: []VersionInfo{
-			{Version: "0.7.0"},
-			{Version: "0.8.0"},
+			{SchemaVersion: "0.7.0"},
+			{SchemaVersion: "0.8.0"},
 		},
 	})
 	defer server.Close()
@@ -726,7 +697,7 @@ func TestGetSchemaSkillsNested(t *testing.T) {
 		t.Fatalf("Failed to create schema: %v", err)
 	}
 
-	skills, err := schema.GetSchemaSkills(context.Background(), WithVersion(testSchemaVersion))
+	skills, err := schema.GetSchemaSkills(context.Background(), WithSchemaVersion(testSchemaVersion))
 	if err != nil {
 		t.Fatalf("Failed to get skills: %v", err)
 	}
@@ -745,7 +716,7 @@ func TestGetSchemaDomainsNested(t *testing.T) {
 		t.Fatalf("Failed to create schema: %v", err)
 	}
 
-	domains, err := schema.GetSchemaDomains(context.Background(), WithVersion(testSchemaVersion))
+	domains, err := schema.GetSchemaDomains(context.Background(), WithSchemaVersion(testSchemaVersion))
 	if err != nil {
 		t.Fatalf("Failed to get domains: %v", err)
 	}
@@ -765,7 +736,7 @@ func TestGetSchemaModules(t *testing.T) {
 	}
 
 	// Note: modules may not exist in all schema versions
-	_, err = schema.GetSchemaModules(context.Background(), WithVersion("0.7.0"))
+	_, err = schema.GetSchemaModules(context.Background(), WithSchemaVersion("0.7.0"))
 	// We don't assert on error since modules might not exist
 	// This test mainly ensures the function doesn't panic
 	_ = err
@@ -990,10 +961,10 @@ func TestSchemaCategoriesCachedByVersion(t *testing.T) {
 	if err := s.Cache(context.Background()); err != nil {
 		t.Fatalf("Cache failed: %v", err)
 	}
-	if _, err := s.GetSchemaModules(context.Background(), WithVersion("0.8.0")); err != nil {
+	if _, err := s.GetSchemaModules(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
 		t.Fatalf("GetSchemaModules first cached call failed: %v", err)
 	}
-	if _, err := s.GetSchemaModules(context.Background(), WithVersion("0.8.0")); err != nil {
+	if _, err := s.GetSchemaModules(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
 		t.Fatalf("GetSchemaModules second cached call failed: %v", err)
 	}
 
@@ -1054,13 +1025,13 @@ func TestClearCache(t *testing.T) {
 	if err := s.Cache(context.Background()); err != nil {
 		t.Fatalf("Cache failed: %v", err)
 	}
-	if _, err := s.GetSchemaSkills(context.Background(), WithVersion("0.8.0")); err != nil {
+	if _, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
 		t.Fatalf("GetSchemaSkills from cache failed: %v", err)
 	}
 
 	s.ClearCache()
 
-	if _, err := s.GetSchemaSkills(context.Background(), WithVersion("0.8.0")); err != nil {
+	if _, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
 		t.Fatalf("GetSchemaSkills after ClearCache failed: %v", err)
 	}
 
@@ -1127,7 +1098,7 @@ func TestReloadCache(t *testing.T) {
 	if err := s.Cache(context.Background()); err != nil {
 		t.Fatalf("Cache failed: %v", err)
 	}
-	first, err := s.GetSchemaSkills(context.Background(), WithVersion("0.8.0"))
+	first, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0"))
 	if err != nil {
 		t.Fatalf("GetSchemaSkills first cached read failed: %v", err)
 	}
@@ -1138,7 +1109,7 @@ func TestReloadCache(t *testing.T) {
 	if err := s.ReloadCache(context.Background()); err != nil {
 		t.Fatalf("ReloadCache failed: %v", err)
 	}
-	second, err := s.GetSchemaSkills(context.Background(), WithVersion("0.8.0"))
+	second, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0"))
 	if err != nil {
 		t.Fatalf("GetSchemaSkills second cached read failed: %v", err)
 	}
@@ -1189,7 +1160,7 @@ func TestGetSchemaModulesRejectsUnsupportedVersionBeforeCategoryFetch(t *testing
 		t.Fatalf("Failed to create schema: %v", err)
 	}
 
-	_, err = s.GetSchemaModules(context.Background(), WithVersion("1.1.0"))
+	_, err = s.GetSchemaModules(context.Background(), WithSchemaVersion("1.1.0"))
 	if err == nil {
 		t.Fatalf("Expected unsupported-version error, got nil")
 	}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -18,13 +18,10 @@ const testSchemaVersion = "0.7.0"
 const invalidVersion = "99.99.99"
 
 const (
-	apiPathSegment           = "api"
-	skillCategoriesEndpoint  = "skill_categories"
-	domainCategoriesEndpoint = "domain_categories"
-	moduleCategoriesEndpoint = "module_categories"
-	pathSkillCategories080   = "/api/0.8.0/skill_categories"
-	pathDomainCategories080  = "/api/0.8.0/domain_categories"
-	pathModuleCategories080  = "/api/0.8.0/module_categories"
+	apiPathSegment          = "api"
+	pathSkillCategories080  = "/api/0.8.0/skill_categories"
+	pathDomainCategories080 = "/api/0.8.0/domain_categories"
+	pathModuleCategories080 = "/api/0.8.0/module_categories"
 )
 
 // mockSchemaResponse returns a mock schema JSON response with $defs section.
@@ -161,16 +158,16 @@ func validateSchemaContent(t *testing.T, content []byte) {
 	t.Helper()
 
 	if len(content) == 0 {
-		t.Errorf("GetRecordSchemaContent() returned empty content")
+		t.Errorf("GetRecordJSONSchema() returned empty content")
 	}
 
 	var jsonMap map[string]any
 	if err := json.Unmarshal(content, &jsonMap); err != nil {
-		t.Errorf("GetRecordSchemaContent() returned invalid JSON: %v", err)
+		t.Errorf("GetRecordJSONSchema() returned invalid JSON: %v", err)
 	}
 }
 
-func TestGetRecordSchemaContent(t *testing.T) {
+func TestGetRecordJSONSchema(t *testing.T) {
 	tests := []struct {
 		name        string
 		version     string
@@ -208,17 +205,17 @@ func TestGetRecordSchemaContent(t *testing.T) {
 				t.Fatalf("Failed to create schema: %v", err)
 			}
 
-			content, err := schema.GetRecordSchemaContent(context.Background(), WithSchemaVersion(tt.version))
+			content, err := schema.GetRecordJSONSchema(context.Background(), WithSchemaVersion(tt.version))
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("GetRecordSchemaContent() expected error but got none")
+					t.Errorf("GetRecordJSONSchema() expected error but got none")
 				}
 
 				return
 			}
 
 			if err != nil {
-				t.Errorf("GetRecordSchemaContent() unexpected error: %v", err)
+				t.Errorf("GetRecordJSONSchema() unexpected error: %v", err)
 			}
 
 			validateSchemaContent(t, content)
@@ -226,7 +223,7 @@ func TestGetRecordSchemaContent(t *testing.T) {
 	}
 }
 
-func TestGetSchema(t *testing.T) {
+func TestGetJSONSchema(t *testing.T) {
 	tests := []struct {
 		name        string
 		version     string
@@ -287,17 +284,17 @@ func TestGetSchema(t *testing.T) {
 				opts = append(opts, WithSchemaVersion(tt.version))
 			}
 
-			content, err := schema.GetSchema(context.Background(), tt.typ, tt.schemaName, opts...)
+			content, err := schema.GetJSONSchema(context.Background(), tt.typ, tt.schemaName, opts...)
 			if tt.expectError {
 				if err == nil {
-					t.Errorf("GetSchema() expected error but got none")
+					t.Errorf("GetJSONSchema() expected error but got none")
 				}
 
 				return
 			}
 
 			if err != nil {
-				t.Errorf("GetSchema() unexpected error: %v", err)
+				t.Errorf("GetJSONSchema() unexpected error: %v", err)
 			}
 
 			validateSchemaContent(t, content)
@@ -832,9 +829,9 @@ func TestDefaultVersion(t *testing.T) {
 		minCount int
 	}{
 		{
-			name: "GetRecordSchemaContent",
+			name: "GetRecordJSONSchema",
 			testFunc: func() error {
-				_, err := schema.GetRecordSchemaContent(context.Background())
+				_, err := schema.GetRecordJSONSchema(context.Background())
 
 				return err
 			},
@@ -874,7 +871,7 @@ func TestDefaultVersion(t *testing.T) {
 	}
 }
 
-func TestVersionsAreCached(t *testing.T) {
+func TestVersionsAreCachedWhenEnabled(t *testing.T) {
 	var versionsCalls int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -895,8 +892,8 @@ func TestVersionsAreCached(t *testing.T) {
 		}
 
 		pathParts := strings.Split(r.URL.Path, "/")
-		if len(pathParts) == 4 && pathParts[1] == "api" &&
-			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+		if len(pathParts) == 4 && pathParts[1] == apiPathSegment &&
+			(pathParts[3] == moduleCategoriesEndpoint || pathParts[3] == skillCategoriesEndpoint || pathParts[3] == domainCategoriesEndpoint) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
@@ -908,25 +905,21 @@ func TestVersionsAreCached(t *testing.T) {
 	}))
 	defer server.Close()
 
-	s, err := New(server.URL)
+	s, err := New(server.URL, WithCache(true))
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
 
-	if err := s.Cache(context.Background()); err != nil {
-		t.Fatalf("Cache failed: %v", err)
-	}
-
 	if _, err := s.GetAvailableSchemaVersions(context.Background()); err != nil {
-		t.Fatalf("GetAvailableSchemaVersions from cache failed: %v", err)
+		t.Fatalf("GetAvailableSchemaVersions failed: %v", err)
 	}
 
 	if _, err := s.GetDefaultSchemaVersion(context.Background()); err != nil {
-		t.Fatalf("GetDefaultSchemaVersion from cache failed: %v", err)
+		t.Fatalf("GetDefaultSchemaVersion failed: %v", err)
 	}
 
 	if _, err := s.GetAvailableSchemaVersions(context.Background()); err != nil {
-		t.Fatalf("GetAvailableSchemaVersions second cached call failed: %v", err)
+		t.Fatalf("GetAvailableSchemaVersions second call failed: %v", err)
 	}
 
 	if got := atomic.LoadInt32(&versionsCalls); got != 1 {
@@ -934,7 +927,7 @@ func TestVersionsAreCached(t *testing.T) {
 	}
 }
 
-func TestSchemaCategoriesCachedByVersion(t *testing.T) {
+func TestSchemaCategoriesCachedByVersionWhenEnabled(t *testing.T) {
 	var categoryCalls int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -977,25 +970,77 @@ func TestSchemaCategoriesCachedByVersion(t *testing.T) {
 	}))
 	defer server.Close()
 
-	s, err := New(server.URL)
+	s, err := New(server.URL, WithCache(true))
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
 
-	if err := s.Cache(context.Background()); err != nil {
-		t.Fatalf("Cache failed: %v", err)
+	if _, err := s.GetSchemaModules(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
+		t.Fatalf("GetSchemaModules first call failed: %v", err)
 	}
 
 	if _, err := s.GetSchemaModules(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
-		t.Fatalf("GetSchemaModules first cached call failed: %v", err)
-	}
-
-	if _, err := s.GetSchemaModules(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
-		t.Fatalf("GetSchemaModules second cached call failed: %v", err)
+		t.Fatalf("GetSchemaModules second call failed: %v", err)
 	}
 
 	if got := atomic.LoadInt32(&categoryCalls); got != 1 {
 		t.Fatalf("expected exactly one categories fetch, got %d", got)
+	}
+}
+
+func TestRecordJSONSchemaCachedWhenEnabled(t *testing.T) {
+	var (
+		versionsCalls int32
+		schemaCalls   int32
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == apiVersionsPath {
+			atomic.AddInt32(&versionsCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(VersionsResponse{
+				Default: VersionInfo{SchemaVersion: "0.8.0"},
+				Versions: []VersionInfo{
+					{SchemaVersion: "0.8.0"},
+				},
+			})
+
+			return
+		}
+
+		if r.URL.Path == "/schema/0.8.0/objects/record" {
+			atomic.AddInt32(&schemaCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockSchemaResponse())
+
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s, err := New(server.URL, WithCache(true))
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	if _, err := s.GetRecordJSONSchema(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
+		t.Fatalf("GetRecordJSONSchema first call failed: %v", err)
+	}
+
+	if _, err := s.GetRecordJSONSchema(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
+		t.Fatalf("GetRecordJSONSchema second call failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&versionsCalls); got != 1 {
+		t.Fatalf("expected one versions fetch with cache enabled, got %d", got)
+	}
+
+	if got := atomic.LoadInt32(&schemaCalls); got != 1 {
+		t.Fatalf("expected one record schema fetch with cache enabled, got %d", got)
 	}
 }
 
@@ -1021,21 +1066,21 @@ func TestClearCache(t *testing.T) {
 			})
 
 			return
-		case "/api/0.8.0/skill_categories":
+		case pathSkillCategories080:
 			atomic.AddInt32(&skillCalls, 1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
 
 			return
-		case "/api/0.8.0/domain_categories":
+		case pathDomainCategories080:
 			atomic.AddInt32(&domainCalls, 1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
 
 			return
-		case "/api/0.8.0/module_categories":
+		case pathModuleCategories080:
 			atomic.AddInt32(&moduleCalls, 1)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
@@ -1050,17 +1095,13 @@ func TestClearCache(t *testing.T) {
 	}))
 	defer server.Close()
 
-	s, err := New(server.URL)
+	s, err := New(server.URL, WithCache(true))
 	if err != nil {
 		t.Fatalf("failed to create schema: %v", err)
 	}
 
-	if err := s.Cache(context.Background()); err != nil {
-		t.Fatalf("Cache failed: %v", err)
-	}
-
 	if _, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
-		t.Fatalf("GetSchemaSkills from cache failed: %v", err)
+		t.Fatalf("GetSchemaSkills first call failed: %v", err)
 	}
 
 	s.ClearCache()
@@ -1077,16 +1118,16 @@ func TestClearCache(t *testing.T) {
 		t.Fatalf("expected two skill fetches, got %d", got)
 	}
 
-	if got := atomic.LoadInt32(&domainCalls); got != 1 {
-		t.Fatalf("expected one domain fetch from initial Cache, got %d", got)
+	if got := atomic.LoadInt32(&domainCalls); got != 0 {
+		t.Fatalf("expected zero domain fetches, got %d", got)
 	}
 
-	if got := atomic.LoadInt32(&moduleCalls); got != 1 {
-		t.Fatalf("expected one module fetch from initial Cache, got %d", got)
+	if got := atomic.LoadInt32(&moduleCalls); got != 0 {
+		t.Fatalf("expected zero module fetches, got %d", got)
 	}
 }
 
-func TestReloadCache(t *testing.T) {
+func TestSchemaCategoriesAreNotCachedByDefault(t *testing.T) {
 	var skillCalls int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1102,24 +1143,15 @@ func TestReloadCache(t *testing.T) {
 			})
 
 			return
-		case "/api/0.8.0/skill_categories":
-			call := atomic.AddInt32(&skillCalls, 1)
+		case pathSkillCategories080:
+			atomic.AddInt32(&skillCalls, 1)
 
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-
-			if call == 1 {
-				_ = json.NewEncoder(w).Encode(SchemaCategories{
-					"skills": {ID: 1, Name: "skills-v1"},
-				})
-			} else {
-				_ = json.NewEncoder(w).Encode(SchemaCategories{
-					"skills": {ID: 1, Name: "skills-v2"},
-				})
-			}
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
 
 			return
-		case "/api/0.8.0/domain_categories", "/api/0.8.0/module_categories":
+		case pathDomainCategories080, pathModuleCategories080:
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
@@ -1138,34 +1170,72 @@ func TestReloadCache(t *testing.T) {
 		t.Fatalf("failed to create schema: %v", err)
 	}
 
-	if err := s.Cache(context.Background()); err != nil {
-		t.Fatalf("Cache failed: %v", err)
+	if _, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
+		t.Fatalf("GetSchemaSkills first call failed: %v", err)
 	}
 
-	first, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0"))
-	if err != nil {
-		t.Fatalf("GetSchemaSkills first cached read failed: %v", err)
-	}
-
-	if first["skills"].Name != "skills-v1" {
-		t.Fatalf("expected first cached value skills-v1, got %q", first["skills"].Name)
-	}
-
-	if err := s.ReloadCache(context.Background()); err != nil {
-		t.Fatalf("ReloadCache failed: %v", err)
-	}
-
-	second, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0"))
-	if err != nil {
-		t.Fatalf("GetSchemaSkills second cached read failed: %v", err)
-	}
-
-	if second["skills"].Name != "skills-v2" {
-		t.Fatalf("expected reloaded cached value skills-v2, got %q", second["skills"].Name)
+	if _, err := s.GetSchemaSkills(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
+		t.Fatalf("GetSchemaSkills second call failed: %v", err)
 	}
 
 	if got := atomic.LoadInt32(&skillCalls); got != 2 {
-		t.Fatalf("expected two skill endpoint calls (cache + reload), got %d", got)
+		t.Fatalf("expected two category fetches without cache, got %d", got)
+	}
+}
+
+func TestRecordJSONSchemaNotCachedByDefault(t *testing.T) {
+	var (
+		versionsCalls int32
+		schemaCalls   int32
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == apiVersionsPath {
+			atomic.AddInt32(&versionsCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(VersionsResponse{
+				Default: VersionInfo{SchemaVersion: "0.8.0"},
+				Versions: []VersionInfo{
+					{SchemaVersion: "0.8.0"},
+				},
+			})
+
+			return
+		}
+
+		if r.URL.Path == "/schema/0.8.0/objects/record" {
+			atomic.AddInt32(&schemaCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockSchemaResponse())
+
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	if _, err := s.GetRecordJSONSchema(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
+		t.Fatalf("GetRecordJSONSchema first call failed: %v", err)
+	}
+
+	if _, err := s.GetRecordJSONSchema(context.Background(), WithSchemaVersion("0.8.0")); err != nil {
+		t.Fatalf("GetRecordJSONSchema second call failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&versionsCalls); got != 2 {
+		t.Fatalf("expected two versions fetches without cache, got %d", got)
+	}
+
+	if got := atomic.LoadInt32(&schemaCalls); got != 2 {
+		t.Fatalf("expected two record schema fetches without cache, got %d", got)
 	}
 }
 

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -884,6 +885,173 @@ func TestDefaultVersion(t *testing.T) {
 				t.Errorf("Expected default version %s, got %v", defaultVersion, requestedVersions)
 			}
 		})
+	}
+}
+
+func TestVersionsAreCached(t *testing.T) {
+	var versionsCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == apiVersionsPath {
+			atomic.AddInt32(&versionsCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(VersionsResponse{
+				Default: VersionInfo{SchemaVersion: "0.8.0"},
+				Versions: []VersionInfo{
+					{SchemaVersion: "0.7.0"},
+					{SchemaVersion: "0.8.0"},
+					{SchemaVersion: "1.0.0"},
+				},
+			})
+
+			return
+		}
+
+		pathParts := strings.Split(r.URL.Path, "/")
+		if len(pathParts) == 4 && pathParts[1] == "api" &&
+			(pathParts[3] == "module_categories" || pathParts[3] == "skill_categories" || pathParts[3] == "domain_categories") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	if err := s.Cache(context.Background()); err != nil {
+		t.Fatalf("Cache failed: %v", err)
+	}
+	if _, err := s.GetAvailableSchemaVersions(context.Background()); err != nil {
+		t.Fatalf("GetAvailableSchemaVersions from cache failed: %v", err)
+	}
+	if _, err := s.GetDefaultSchemaVersion(context.Background()); err != nil {
+		t.Fatalf("GetDefaultSchemaVersion from cache failed: %v", err)
+	}
+	if _, err := s.GetAvailableSchemaVersions(context.Background()); err != nil {
+		t.Fatalf("GetAvailableSchemaVersions second cached call failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&versionsCalls); got != 1 {
+		t.Fatalf("expected exactly one /api/versions call, got %d", got)
+	}
+}
+
+func TestSchemaCategoriesCachedByVersion(t *testing.T) {
+	var categoryCalls int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case apiVersionsPath:
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(VersionsResponse{
+				Default: VersionInfo{SchemaVersion: "0.8.0"},
+				Versions: []VersionInfo{
+					{SchemaVersion: "0.8.0"},
+				},
+			})
+			return
+		case "/api/0.8.0/skill_categories":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+			return
+		case "/api/0.8.0/domain_categories":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+			return
+		case "/api/0.8.0/module_categories":
+			atomic.AddInt32(&categoryCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	s, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+
+	if err := s.Cache(context.Background()); err != nil {
+		t.Fatalf("Cache failed: %v", err)
+	}
+	if _, err := s.GetSchemaModules(context.Background(), WithVersion("0.8.0")); err != nil {
+		t.Fatalf("GetSchemaModules first cached call failed: %v", err)
+	}
+	if _, err := s.GetSchemaModules(context.Background(), WithVersion("0.8.0")); err != nil {
+		t.Fatalf("GetSchemaModules second cached call failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&categoryCalls); got != 1 {
+		t.Fatalf("expected exactly one categories fetch, got %d", got)
+	}
+}
+
+func TestGetSchemaModulesRejectsUnsupportedVersionBeforeCategoryFetch(t *testing.T) {
+	categoryEndpointHit := false
+	versionsEndpointCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == apiVersionsPath {
+			versionsEndpointCalls++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(VersionsResponse{
+				Default: VersionInfo{SchemaVersion: "1.0.0"},
+				Versions: []VersionInfo{
+					{SchemaVersion: "0.8.0"},
+					{SchemaVersion: "1.0.0"},
+				},
+			})
+
+			return
+		}
+
+		if strings.HasPrefix(r.URL.Path, "/api/") && strings.HasSuffix(r.URL.Path, "/module_categories") {
+			categoryEndpointHit = true
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(mockCategoriesResponse())
+
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	s, err := New(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to create schema: %v", err)
+	}
+
+	_, err = s.GetSchemaModules(context.Background(), WithVersion("1.1.0"))
+	if err == nil {
+		t.Fatalf("Expected unsupported-version error, got nil")
+	}
+	if !strings.Contains(err.Error(), `schema version "1.1.0" is not supported`) {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if categoryEndpointHit {
+		t.Fatalf("Category endpoint should not be called for unsupported version")
+	}
+	if versionsEndpointCalls != 1 {
+		t.Fatalf("Expected one versions fetch, got %d", versionsEndpointCalls)
 	}
 }
 

--- a/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
+++ b/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
@@ -1,0 +1,101 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+syntax = "proto3";
+
+package agntcy.oasfsdk.schema.v1;
+
+import "google/protobuf/struct.proto";
+
+// SchemaService provides methods to fetch schema metadata and taxonomy categories.
+service SchemaService {
+  // GetDefaultSchemaVersion returns the default schema version configured by the schema server.
+  rpc GetDefaultSchemaVersion(GetDefaultSchemaVersionRequest) returns (GetDefaultSchemaVersionResponse);
+
+  // GetAvailableSchemaVersions returns all schema versions supported by the schema server.
+  rpc GetAvailableSchemaVersions(GetAvailableSchemaVersionsRequest) returns (GetAvailableSchemaVersionsResponse);
+
+  // GetRecordSchemaContent returns the full record JSON schema for a version.
+  rpc GetRecordSchemaContent(GetRecordSchemaContentRequest) returns (GetRecordSchemaContentResponse);
+
+  // GetSchemaSkills returns nested skill categories for a version.
+  rpc GetSchemaSkills(GetSchemaSkillsRequest) returns (GetSchemaSkillsResponse);
+
+  // GetSchemaDomains returns nested domain categories for a version.
+  rpc GetSchemaDomains(GetSchemaDomainsRequest) returns (GetSchemaDomainsResponse);
+
+  // GetSchemaModules returns nested module categories for a version.
+  rpc GetSchemaModules(GetSchemaModulesRequest) returns (GetSchemaModulesResponse);
+}
+
+message GetDefaultSchemaVersionRequest {
+  // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
+  string schema_url = 1;
+}
+
+message GetDefaultSchemaVersionResponse {
+  // Default schema version returned by the schema server.
+  string version = 1;
+}
+
+message GetAvailableSchemaVersionsRequest {
+  // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
+  string schema_url = 1;
+}
+
+message GetAvailableSchemaVersionsResponse {
+  // List of schema versions supported by the schema server.
+  repeated string versions = 1;
+}
+
+message GetRecordSchemaContentRequest {
+  // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
+  string schema_url = 1;
+
+  // Optional schema version. If empty, the schema server default is used.
+  string schema_version = 2;
+}
+
+message GetRecordSchemaContentResponse {
+  // Full record schema represented as structured JSON.
+  google.protobuf.Struct schema = 1;
+}
+
+message GetSchemaSkillsRequest {
+  // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
+  string schema_url = 1;
+
+  // Optional schema version. If empty, the schema server default is used.
+  string schema_version = 2;
+}
+
+message GetSchemaSkillsResponse {
+  // Nested skill categories represented as structured JSON.
+  google.protobuf.Struct data = 1;
+}
+
+message GetSchemaDomainsRequest {
+  // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
+  string schema_url = 1;
+
+  // Optional schema version. If empty, the schema server default is used.
+  string schema_version = 2;
+}
+
+message GetSchemaDomainsResponse {
+  // Nested domain categories represented as structured JSON.
+  google.protobuf.Struct data = 1;
+}
+
+message GetSchemaModulesRequest {
+  // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
+  string schema_url = 1;
+
+  // Optional schema version. If empty, the schema server default is used.
+  string schema_version = 2;
+}
+
+message GetSchemaModulesResponse {
+  // Nested module categories represented as structured JSON.
+  google.protobuf.Struct data = 1;
+}

--- a/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
+++ b/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
@@ -18,6 +18,9 @@ service SchemaService {
   // GetRecordJSONSchema returns the full record JSON schema for a version.
   rpc GetRecordJSONSchema(GetRecordJSONSchemaRequest) returns (GetRecordJSONSchemaResponse);
 
+  // GetJSONSchema returns a JSON schema for a full schema URL.
+  rpc GetJSONSchema(GetJSONSchemaRequest) returns (GetJSONSchemaResponse);
+
   // GetSchemaSkills returns nested skill categories for a version.
   rpc GetSchemaSkills(GetSchemaSkillsRequest) returns (GetSchemaSkillsResponse);
 
@@ -61,6 +64,16 @@ message GetRecordJSONSchemaRequest {
 
 message GetRecordJSONSchemaResponse {
   // Full record schema represented as structured JSON.
+  google.protobuf.Struct schema = 1;
+}
+
+message GetJSONSchemaRequest {
+  // Full schema URL (for example https://schema.oasf.outshift.com/schema/1.0.0/objects/record).
+  string url = 1;
+}
+
+message GetJSONSchemaResponse {
+  // JSON schema represented as structured JSON.
   google.protobuf.Struct schema = 1;
 }
 

--- a/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
+++ b/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
@@ -15,8 +15,8 @@ service SchemaService {
   // GetAvailableSchemaVersions returns all schema versions supported by the schema server.
   rpc GetAvailableSchemaVersions(GetAvailableSchemaVersionsRequest) returns (GetAvailableSchemaVersionsResponse);
 
-  // GetRecordSchemaContent returns the full record JSON schema for a version.
-  rpc GetRecordSchemaContent(GetRecordSchemaContentRequest) returns (GetRecordSchemaContentResponse);
+  // GetRecordJSONSchema returns the full record JSON schema for a version.
+  rpc GetRecordJSONSchema(GetRecordJSONSchemaRequest) returns (GetRecordJSONSchemaResponse);
 
   // GetSchemaSkills returns nested skill categories for a version.
   rpc GetSchemaSkills(GetSchemaSkillsRequest) returns (GetSchemaSkillsResponse);
@@ -26,6 +26,9 @@ service SchemaService {
 
   // GetSchemaModules returns nested module categories for a version.
   rpc GetSchemaModules(GetSchemaModulesRequest) returns (GetSchemaModulesResponse);
+
+  // ClearSchemaCache clears cached schema data for the provided schema URL.
+  rpc ClearSchemaCache(ClearSchemaCacheRequest) returns (ClearSchemaCacheResponse);
 }
 
 message GetDefaultSchemaVersionRequest {
@@ -48,7 +51,7 @@ message GetAvailableSchemaVersionsResponse {
   repeated string versions = 1;
 }
 
-message GetRecordSchemaContentRequest {
+message GetRecordJSONSchemaRequest {
   // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
   string schema_url = 1;
 
@@ -56,7 +59,7 @@ message GetRecordSchemaContentRequest {
   string schema_version = 2;
 }
 
-message GetRecordSchemaContentResponse {
+message GetRecordJSONSchemaResponse {
   // Full record schema represented as structured JSON.
   google.protobuf.Struct schema = 1;
 }
@@ -98,4 +101,14 @@ message GetSchemaModulesRequest {
 message GetSchemaModulesResponse {
   // Nested module categories represented as structured JSON.
   google.protobuf.Struct data = 1;
+}
+
+message ClearSchemaCacheRequest {
+  // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
+  string schema_url = 1;
+}
+
+message ClearSchemaCacheResponse {
+  // True when cache was cleared successfully.
+  bool cleared = 1;
 }

--- a/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
+++ b/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
@@ -77,6 +77,18 @@ message GetJSONSchemaResponse {
   google.protobuf.Struct schema = 1;
 }
 
+// TaxonomyItem represents a single node in a nested OASF taxonomy tree.
+message TaxonomyItem {
+  int32 id = 1;
+  string name = 2;
+  string caption = 3;
+  string description = 4;
+  bool category = 5;
+  bool deprecated = 6;
+  // Child items keyed by their slug (for example "natural_language_processing").
+  map<string, TaxonomyItem> classes = 7;
+}
+
 message GetSchemaSkillsRequest {
   // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
   string schema_url = 1;
@@ -86,8 +98,8 @@ message GetSchemaSkillsRequest {
 }
 
 message GetSchemaSkillsResponse {
-  // Nested skill categories represented as structured JSON.
-  google.protobuf.Struct data = 1;
+  // Top-level skill categories keyed by slug.
+  map<string, TaxonomyItem> items = 1;
 }
 
 message GetSchemaDomainsRequest {
@@ -99,8 +111,8 @@ message GetSchemaDomainsRequest {
 }
 
 message GetSchemaDomainsResponse {
-  // Nested domain categories represented as structured JSON.
-  google.protobuf.Struct data = 1;
+  // Top-level domain categories keyed by slug.
+  map<string, TaxonomyItem> items = 1;
 }
 
 message GetSchemaModulesRequest {
@@ -112,8 +124,8 @@ message GetSchemaModulesRequest {
 }
 
 message GetSchemaModulesResponse {
-  // Nested module categories represented as structured JSON.
-  google.protobuf.Struct data = 1;
+  // Top-level module categories keyed by slug.
+  map<string, TaxonomyItem> items = 1;
 }
 
 message ClearSchemaCacheRequest {

--- a/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
+++ b/proto/agntcy/oasfsdk/schema/v1/schema_service.proto
@@ -29,9 +29,6 @@ service SchemaService {
 
   // GetSchemaModules returns nested module categories for a version.
   rpc GetSchemaModules(GetSchemaModulesRequest) returns (GetSchemaModulesResponse);
-
-  // ClearSchemaCache clears cached schema data for the provided schema URL.
-  rpc ClearSchemaCache(ClearSchemaCacheRequest) returns (ClearSchemaCacheResponse);
 }
 
 message GetDefaultSchemaVersionRequest {
@@ -126,14 +123,4 @@ message GetSchemaModulesRequest {
 message GetSchemaModulesResponse {
   // Top-level module categories keyed by slug.
   map<string, TaxonomyItem> items = 1;
-}
-
-message ClearSchemaCacheRequest {
-  // URL of the OASF schema server (for example https://schema.oasf.outshift.com).
-  string schema_url = 1;
-}
-
-message ClearSchemaCacheResponse {
-  // True when cache was cleared successfully.
-  bool cleared = 1;
 }


### PR DESCRIPTION
1. `schema` package GetSchemaSkills etc. now returns Go struct with nested taxonomy
2. `schema` package optionally caches the schema dynamically (only results that has been requested) so as long as it lives, it won't hit the OASF API anymore. The cache can be reloaded as well.
3. added protos so the schema package can be used via the server

Closes #123 