### PR TITLE
feat(schema): agentskill markdown translator

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -324,12 +324,26 @@ All convenience methods accept optional `WithSchemaVersion()` option. If omitted
 
 ### Accessing Agent Skills data from a record
 
-The translator package can render a spec-compliant `SKILL.md` directly from a record.
+The translator package can convert between SKILL.md content and OASF records directly.
+
+Convert a SKILL.md to a record:
 
 ```go
-skillMarkdown, err := translator.BuildSkillMarkdownFromRecord(record)
+skillData, _ := structpb.NewStruct(map[string]any{
+  "skillMarkdown": "---\nname: my-skill\ndescription: Does something.\n---\nBody here.\n",
+})
+record, err := translator.SkillMarkdownToRecord(skillData)
 if err != nil {
-  log.Fatalf("Failed to build SKILL.md: %v", err)
+  log.Fatalf("Failed to convert SKILL.md to record: %v", err)
+}
+```
+
+Render a SKILL.md from a record:
+
+```go
+skillMarkdown, err := translator.RecordToSkillMarkdown(record)
+if err != nil {
+  log.Fatalf("Failed to render SKILL.md from record: %v", err)
 }
 fmt.Printf("SKILL.md content:\n%s", skillMarkdown)
 ```

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -4,7 +4,7 @@ go 1.26.1
 
 require (
 	buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260128161637-a77f334c8c86.1
-	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1
+	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1
 	google.golang.org/protobuf v1.36.11
 )
 

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -2,6 +2,8 @@ buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260128161637-a77f
 buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260128161637-a77f334c8c86.1/go.mod h1:EEQp9sY+88ieMjKf9W4Uf9t3X6qV1nHY0DcGOxsMlac=
 buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1 h1:c5Knf+Ki5RRjRAZIK11brQyaI2On4lOvel/cNg4hnJc=
 buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1/go.mod h1:y7UzNChPK2OBXQxpwimQg6fSgSFLC1jZXTk9Y7HFfNc=
+buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1 h1:zG4FFqTORpGsQVx1fo5qjcYZbNZqk56B6y0986Nexzg=
+buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1/go.mod h1:y7UzNChPK2OBXQxpwimQg6fSgSFLC1jZXTk9Y7HFfNc=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/pkg/translator/agentskills.go
+++ b/pkg/translator/agentskills.go
@@ -18,23 +18,13 @@ import (
 
 const AgentSkillsModuleName = "agentskills"
 
-// MarkdownOption configures the markdown output.
-type MarkdownOption func(*markdownOptions)
-
-type markdownOptions struct {
-	body string
-}
-
-// WithBody sets the markdown body appended after frontmatter.
-func WithBody(body string) MarkdownOption {
-	return func(opts *markdownOptions) {
-		opts.body = body
-	}
-}
-
-// RecordToSkillMarkdown renders SKILL.md content from a record containing the agentskills module.
-// The record must have an agentskills module with a skill_manifest field.
-func RecordToSkillMarkdown(record *structpb.Struct, opts ...MarkdownOption) (string, error) {
+// RecordToSkillMarkdown renders a spec-compliant SKILL.md from a record containing
+// the agentskills module. The body is read from the skill_body field in the module data.
+//
+// The SKILL.md frontmatter contains exactly the fields defined by the Agent Skills
+// specification: name, description, license, compatibility, metadata, and allowed-tools.
+// There is no top-level version field in the spec; version belongs inside metadata.
+func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 	if record == nil {
 		return "", errors.New("record is nil")
 	}
@@ -51,12 +41,7 @@ func RecordToSkillMarkdown(record *structpb.Struct, opts ...MarkdownOption) (str
 
 	manifest := manifestField.GetStructValue()
 	if manifest == nil {
-		return "", errors.New("skill_manifest is missing")
-	}
-
-	options := &markdownOptions{}
-	for _, opt := range opts {
-		opt(options)
+		return "", errors.New("skill_manifest is not a struct")
 	}
 
 	manifestMap := manifest.AsMap()
@@ -69,15 +54,8 @@ func RecordToSkillMarkdown(record *structpb.Struct, opts ...MarkdownOption) (str
 
 	license := getString(manifestMap, "license")
 	compatibility := getString(manifestMap, "compatibility")
-	version := getString(manifestMap, "version")
 	allowedTools := getStringSlice(manifestMap, "allowed_tools")
-	frontmatterMetadata := getStringMap(manifestMap, "frontmatter_metadata")
-
-	if version != "" {
-		if _, ok := frontmatterMetadata["version"]; !ok {
-			frontmatterMetadata["version"] = version
-		}
-	}
+	metadata := getStringMap(manifestMap, "frontmatter_metadata")
 
 	lines := []string{"---"}
 	lines = append(lines, "name: "+yamlScalar(name))
@@ -91,33 +69,29 @@ func RecordToSkillMarkdown(record *structpb.Struct, opts ...MarkdownOption) (str
 		lines = append(lines, "compatibility: "+yamlScalar(compatibility))
 	}
 
-	if version != "" {
-		lines = append(lines, "version: "+yamlScalar(version))
-	}
-
 	if len(allowedTools) > 0 {
 		lines = append(lines, "allowed-tools: "+strings.Join(allowedTools, " "))
 	}
 
-	if len(frontmatterMetadata) > 0 {
+	if len(metadata) > 0 {
 		lines = append(lines, "metadata:")
 
-		keys := make([]string, 0, len(frontmatterMetadata))
-		for key := range frontmatterMetadata {
+		keys := make([]string, 0, len(metadata))
+		for key := range metadata {
 			keys = append(keys, key)
 		}
 
 		sort.Strings(keys)
 
 		for _, key := range keys {
-			value := frontmatterMetadata[key]
-			lines = append(lines, "  "+key+": "+yamlScalar(value))
+			lines = append(lines, "  "+key+": "+yamlScalar(metadata[key]))
 		}
 	}
 
 	lines = append(lines, "---")
 
-	body := strings.TrimSpace(options.body)
+	// Read body from skill_body in module data.
+	body := strings.TrimSpace(moduleData.GetFields()["skill_body"].GetStringValue())
 	if body != "" {
 		lines = append(lines, "", body)
 	} else {
@@ -130,6 +104,10 @@ func RecordToSkillMarkdown(record *structpb.Struct, opts ...MarkdownOption) (str
 // SkillMarkdownToRecord converts a SKILL.md file content into an OASF-compliant record.
 // The input must be wrapped as {"skillMarkdown": "<content>"}.
 // Generates records using the specified schema version (via WithVersion option) or the default schema version.
+//
+// The spec-defined frontmatter fields are: name, description, license, compatibility,
+// metadata, and allowed-tools. There is no top-level version field; version should live
+// inside metadata if needed.
 func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption) (*structpb.Struct, error) {
 	mdVal, ok := skillData.GetFields()["skillMarkdown"]
 	if !ok {
@@ -141,31 +119,30 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 		return nil, errors.New("'skillMarkdown' is empty")
 	}
 
-	name, description, version, license, compatibility, allowedTools, metadata, body, err := parseSkillMarkdownContent(content)
+	name, description, license, compatibility, allowedTools, metadata, body, err := parseSkillMarkdownContent(content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SKILL.md content: %w", err)
 	}
 
-	recordName := name
-	if recordName == "" {
-		recordName = "generated-skill-agent"
+	// Derive record-level version from metadata["version"] if present, else use default.
+	recordVersion := defaultVersion
+	if v, ok := metadata["version"]; ok && v != "" {
+		recordVersion = v
 	}
 
-	recordDescription := description
-	if recordDescription == "" {
-		recordDescription = "Agent generated from SKILL.md"
-	}
-
-	recordVersion := version
-	if recordVersion == "" {
-		recordVersion = defaultVersion
+	// Derive authors from metadata["author"] if present.
+	authors := []*structpb.Value{}
+	if author, ok := metadata["author"]; ok && author != "" {
+		authors = []*structpb.Value{
+			{Kind: &structpb.Value_StringValue{StringValue: author}},
+		}
 	}
 
 	createdAt := time.Now().UTC().Format(time.RFC3339)
 
-	// Build skill_manifest struct fields.
+	// Build skill_manifest struct fields using only spec-defined frontmatter keys.
 	manifestFields := map[string]*structpb.Value{
-		"name": {Kind: &structpb.Value_StringValue{StringValue: name}},
+		"name":        {Kind: &structpb.Value_StringValue{StringValue: name}},
 		"description": {Kind: &structpb.Value_StringValue{StringValue: description}},
 	}
 
@@ -175,10 +152,6 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 
 	if compatibility != "" {
 		manifestFields["compatibility"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: compatibility}}
-	}
-
-	if version != "" {
-		manifestFields["version"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: version}}
 	}
 
 	if len(allowedTools) > 0 {
@@ -215,12 +188,10 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 		moduleDataFields["skill_body"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: body}}
 	}
 
-	moduleData := &structpb.Struct{Fields: moduleDataFields}
-
 	agentSkillsModule := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"name": {Kind: &structpb.Value_StringValue{StringValue: AgentSkillsModuleName}},
-			"data": {Kind: &structpb.Value_StructValue{StructValue: moduleData}},
+			"data": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: moduleDataFields}}},
 		},
 	}
 
@@ -241,25 +212,19 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 
 	record := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"name":           {Kind: &structpb.Value_StringValue{StringValue: recordName}},
+			"name":           {Kind: &structpb.Value_StringValue{StringValue: name}},
 			"schema_version": {Kind: &structpb.Value_StringValue{StringValue: targetVersion}},
 			"version":        {Kind: &structpb.Value_StringValue{StringValue: recordVersion}},
-			"description":    {Kind: &structpb.Value_StringValue{StringValue: recordDescription}},
+			"description":    {Kind: &structpb.Value_StringValue{StringValue: description}},
 			"authors": {
-				Kind: &structpb.Value_ListValue{
-					ListValue: &structpb.ListValue{Values: []*structpb.Value{}},
-				},
+				Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: authors}},
 			},
 			"created_at": {Kind: &structpb.Value_StringValue{StringValue: createdAt}},
 			"skills": {
-				Kind: &structpb.Value_ListValue{
-					ListValue: &structpb.ListValue{Values: []*structpb.Value{}},
-				},
+				Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: []*structpb.Value{}}},
 			},
 			"domains": {
-				Kind: &structpb.Value_ListValue{
-					ListValue: &structpb.ListValue{Values: []*structpb.Value{}},
-				},
+				Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: []*structpb.Value{}}},
 			},
 			"modules": {
 				Kind: &structpb.Value_ListValue{
@@ -276,11 +241,13 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 	return record, nil
 }
 
-// parseSkillMarkdownContent parses a SKILL.md file and returns its components.
-func parseSkillMarkdownContent(content string) (name, description, version, license, compatibility string, allowedTools []string, metadata map[string]string, body string, err error) {
+// parseSkillMarkdownContent parses a SKILL.md and returns its spec-defined components.
+// Spec fields: name, description, license, compatibility, allowed-tools, metadata.
+// There is no top-level version field in the spec.
+func parseSkillMarkdownContent(content string) (name, description, license, compatibility string, allowedTools []string, metadata map[string]string, body string, err error) {
 	sections := strings.SplitN(content, "---", 3)
 	if len(sections) < 3 {
-		return "", "", "", "", "", nil, nil, "", errors.New("invalid SKILL.md: missing frontmatter delimiters")
+		return "", "", "", "", nil, nil, "", errors.New("invalid SKILL.md: missing frontmatter delimiters")
 	}
 
 	frontmatter := strings.TrimSpace(sections[1])
@@ -319,21 +286,19 @@ func parseSkillMarkdownContent(content string) (name, description, version, lice
 			license = v
 		case "compatibility":
 			compatibility = v
-		case "version":
-			version = v
 		case "allowed-tools":
 			allowedTools = strings.Fields(v)
 		}
 	}
 
 	if name == "" || description == "" {
-		return "", "", "", "", "", nil, nil, "", errors.New("SKILL.md must include name and description in frontmatter")
+		return "", "", "", "", nil, nil, "", errors.New("SKILL.md must include name and description in frontmatter")
 	}
 
-	return name, description, version, license, compatibility, allowedTools, metadata, body, nil
+	return name, description, license, compatibility, allowedTools, metadata, body, nil
 }
 
-// splitYAMLKeyValue splits a YAML "key: value" line.
+// splitYAMLKeyValue splits a YAML "key: value" line and unquotes quoted values.
 func splitYAMLKeyValue(line string) (string, string) {
 	parts := strings.SplitN(line, ":", 2)
 	key := strings.TrimSpace(parts[0])
@@ -374,8 +339,7 @@ func getStringSlice(data map[string]any, key string) []string {
 	case []any:
 		result := make([]string, 0, len(typed))
 		for _, item := range typed {
-			str, ok := item.(string)
-			if ok {
+			if str, ok := item.(string); ok {
 				result = append(result, str)
 			}
 		}

--- a/pkg/translator/agentskills.go
+++ b/pkg/translator/agentskills.go
@@ -25,6 +25,12 @@ const (
 	agentSkillsModuleID   = 10302
 )
 
+const (
+	frontmatterParts    = 3
+	yamlKeyValueParts   = 2
+	frontmatterMinParts = 3
+)
+
 // RecordToSkillMarkdown returns the full SKILL.md content for a record containing
 // the agentskills module (name: "core/language_model/agentskills").
 //
@@ -51,6 +57,12 @@ func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 		return string(decoded), nil
 	}
 
+	return buildSkillMarkdownFromManifest(moduleData)
+}
+
+// buildSkillMarkdownFromManifest reconstructs a SKILL.md frontmatter string from the
+// skill_manifest stored in the agentskills module data. Used as fallback when no artifact is present.
+func buildSkillMarkdownFromManifest(moduleData *structpb.Struct) (string, error) {
 	manifestField := moduleData.GetFields()["skill_manifest"]
 	if manifestField == nil {
 		return "", errors.New("skill_manifest is missing")
@@ -70,10 +82,7 @@ func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 	}
 
 	license := getString(manifestMap, "license")
-	// version is stored in the manifest for the record but is NOT a spec frontmatter field;
-	// surface it back under metadata.version so the SKILL.md stays spec-compliant.
 	version := getString(manifestMap, "version")
-	// compatibility is stored as []string in the schema; join with ", " for the SKILL.md scalar.
 	compatibilityItems := getStringSlice(manifestMap, "compatibility")
 	compatibility := strings.Join(compatibilityItems, ", ")
 	allowedTools := getStringSlice(manifestMap, "allowed_tools")
@@ -86,6 +95,11 @@ func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 		}
 	}
 
+	return renderSkillMarkdownFrontmatter(name, description, license, compatibility, allowedTools, metadata), nil
+}
+
+// renderSkillMarkdownFrontmatter renders the YAML frontmatter block for a SKILL.md file.
+func renderSkillMarkdownFrontmatter(name, description, license, compatibility string, allowedTools []string, metadata map[string]string) string {
 	lines := []string{"---"}
 	lines = append(lines, "name: "+yamlScalar(name))
 	lines = append(lines, "description: "+yamlScalar(description))
@@ -120,15 +134,12 @@ func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 	lines = append(lines, "---")
 	lines = append(lines, "")
 
-	return strings.Join(lines, "\n") + "\n", nil
+	return strings.Join(lines, "\n") + "\n"
 }
 
 // SkillMarkdownToRecord converts a SKILL.md file content into an OASF-compliant record.
 // The input must be wrapped as {"skillMarkdown": "<content>"}.
 // Generates records using the specified schema version (via WithVersion option) or the default schema version.
-//
-// The SKILL.md body is not stored in the record because the agentskills_data schema
-// has no field for it. Only the frontmatter fields are persisted.
 func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption) (*structpb.Struct, error) {
 	mdVal, ok := skillData.GetFields()["skillMarkdown"]
 	if !ok {
@@ -140,118 +151,32 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 		return nil, errors.New("'skillMarkdown' is empty")
 	}
 
-	name, description, license, compatibility, allowedTools, metadata, err := parseSkillMarkdownContent(content)
+	parsed, err := parseSkillMarkdownContent(content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SKILL.md content: %w", err)
 	}
 
 	// version is not a spec frontmatter field; source it from metadata["version"].
-	version := metadata["version"]
+	version := parsed.metadata["version"]
 
-	// Derive record-level version from metadata["version"], else default.
 	recordVersion := defaultVersion
 	if version != "" {
 		recordVersion = version
 	}
 
-	// Derive authors from metadata["author"] if present.
-	authors := []*structpb.Value{}
-	if author, ok := metadata["author"]; ok && author != "" {
-		authors = []*structpb.Value{
-			{Kind: &structpb.Value_StringValue{StringValue: author}},
-		}
-	}
+	authors := buildAuthors(parsed.metadata)
+	manifestFields := buildManifestFields(parsed, version)
+	moduleDataFields := buildModuleDataFields(manifestFields)
+	artifactStruct := buildArtifactStruct(content)
+	agentSkillsModule := buildAgentSkillsModule(moduleDataFields, artifactStruct)
 
-	createdAt := time.Now().UTC().Format(time.RFC3339)
-
-	// Build skill_manifest fields matching the agentskills_manifest schema.
-	manifestFields := map[string]*structpb.Value{
-		"name":        {Kind: &structpb.Value_StringValue{StringValue: name}},
-		"description": {Kind: &structpb.Value_StringValue{StringValue: description}},
-	}
-
-	if license != "" {
-		manifestFields["license"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: license}}
-	}
-
-	if version != "" {
-		manifestFields["version"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: version}}
-	}
-
-	// compatibility is array of string in the schema; store as a single-element array.
-	if compatibility != "" {
-		manifestFields["compatibility"] = &structpb.Value{
-			Kind: &structpb.Value_ListValue{
-				ListValue: &structpb.ListValue{
-					Values: []*structpb.Value{
-						{Kind: &structpb.Value_StringValue{StringValue: compatibility}},
-					},
-				},
-			},
-		}
-	}
-
-	if len(allowedTools) > 0 {
-		toolValues := make([]*structpb.Value, 0, len(allowedTools))
-		for _, tool := range allowedTools {
-			toolValues = append(toolValues, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: tool}})
-		}
-
-		manifestFields["allowed_tools"] = &structpb.Value{
-			Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: toolValues}},
-		}
-	}
-
-	if len(metadata) > 0 {
-		metaFields := make(map[string]*structpb.Value, len(metadata))
-		for k, v := range metadata {
-			metaFields[k] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: v}}
-		}
-
-		manifestFields["frontmatter_metadata"] = &structpb.Value{
-			Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: metaFields}},
-		}
-	}
-
-	// Build agentskills_data (only schema-defined fields: skill_file, skill_manifest).
-	moduleDataFields := map[string]*structpb.Value{
-		"skill_file": {Kind: &structpb.Value_StringValue{StringValue: "SKILL.md"}},
-		"skill_manifest": {
-			Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: manifestFields}},
-		},
-	}
-
-	// Build module.artifact: store the full SKILL.md (including body) as base64-encoded data.
-	contentBytes := []byte(content)
-	encoded := base64.StdEncoding.EncodeToString(contentBytes)
-	sum := sha256.Sum256(contentBytes)
-	digest := fmt.Sprintf("sha256:%x", sum)
-
-	artifactStruct := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"media_type": {Kind: &structpb.Value_StringValue{StringValue: agentSkillsMediaType}},
-			"size":       {Kind: &structpb.Value_NumberValue{NumberValue: float64(len(contentBytes))}},
-			"digest":     {Kind: &structpb.Value_StringValue{StringValue: digest}},
-			"data":       {Kind: &structpb.Value_StringValue{StringValue: encoded}},
-		},
-	}
-
-	agentSkillsModule := &structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"name":     {Kind: &structpb.Value_StringValue{StringValue: AgentSkillsModuleName}},
-			"id":       {Kind: &structpb.Value_NumberValue{NumberValue: agentSkillsModuleID}},
-			"data":     {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: moduleDataFields}}},
-			"artifact": {Kind: &structpb.Value_StructValue{StructValue: artifactStruct}},
-		},
-	}
-
-	// Determine target schema version.
 	options := &translatorOptions{}
 	for _, opt := range opts {
 		opt(options)
 	}
 
 	targetVersion := DefaultSchemaVersion
+
 	if options.version != "" {
 		if err := validateMajorVersion(options.version); err != nil {
 			return nil, err
@@ -260,16 +185,117 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 		targetVersion = options.version
 	}
 
-	record := &structpb.Struct{
+	return buildRecord(parsed.name, parsed.description, targetVersion, recordVersion, authors, agentSkillsModule), nil
+}
+
+func buildAuthors(metadata map[string]string) []*structpb.Value {
+	if author, ok := metadata["author"]; ok && author != "" {
+		return []*structpb.Value{
+			{Kind: &structpb.Value_StringValue{StringValue: author}},
+		}
+	}
+
+	return []*structpb.Value{}
+}
+
+func buildManifestFields(parsed skillMarkdownFields, version string) map[string]*structpb.Value {
+	fields := map[string]*structpb.Value{
+		"name":        {Kind: &structpb.Value_StringValue{StringValue: parsed.name}},
+		"description": {Kind: &structpb.Value_StringValue{StringValue: parsed.description}},
+	}
+
+	if parsed.license != "" {
+		fields["license"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: parsed.license}}
+	}
+
+	if version != "" {
+		fields["version"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: version}}
+	}
+
+	if parsed.compatibility != "" {
+		fields["compatibility"] = &structpb.Value{
+			Kind: &structpb.Value_ListValue{
+				ListValue: &structpb.ListValue{
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: parsed.compatibility}},
+					},
+				},
+			},
+		}
+	}
+
+	if len(parsed.allowedTools) > 0 {
+		toolValues := make([]*structpb.Value, 0, len(parsed.allowedTools))
+		for _, tool := range parsed.allowedTools {
+			toolValues = append(toolValues, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: tool}})
+		}
+
+		fields["allowed_tools"] = &structpb.Value{
+			Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: toolValues}},
+		}
+	}
+
+	if len(parsed.metadata) > 0 {
+		metaFields := make(map[string]*structpb.Value, len(parsed.metadata))
+		for k, v := range parsed.metadata {
+			metaFields[k] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: v}}
+		}
+
+		fields["frontmatter_metadata"] = &structpb.Value{
+			Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: metaFields}},
+		}
+	}
+
+	return fields
+}
+
+func buildModuleDataFields(manifestFields map[string]*structpb.Value) map[string]*structpb.Value {
+	return map[string]*structpb.Value{
+		"skill_file": {Kind: &structpb.Value_StringValue{StringValue: "SKILL.md"}},
+		"skill_manifest": {
+			Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: manifestFields}},
+		},
+	}
+}
+
+func buildArtifactStruct(content string) *structpb.Struct {
+	contentBytes := []byte(content)
+	encoded := base64.StdEncoding.EncodeToString(contentBytes)
+	sum := sha256.Sum256(contentBytes)
+	digest := fmt.Sprintf("sha256:%x", sum)
+
+	return &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"media_type": {Kind: &structpb.Value_StringValue{StringValue: agentSkillsMediaType}},
+			"size":       {Kind: &structpb.Value_NumberValue{NumberValue: float64(len(contentBytes))}},
+			"digest":     {Kind: &structpb.Value_StringValue{StringValue: digest}},
+			"data":       {Kind: &structpb.Value_StringValue{StringValue: encoded}},
+		},
+	}
+}
+
+func buildAgentSkillsModule(moduleDataFields map[string]*structpb.Value, artifactStruct *structpb.Struct) *structpb.Struct {
+	return &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"name":     {Kind: &structpb.Value_StringValue{StringValue: AgentSkillsModuleName}},
+			"id":       {Kind: &structpb.Value_NumberValue{NumberValue: agentSkillsModuleID}},
+			"data":     {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: moduleDataFields}}},
+			"artifact": {Kind: &structpb.Value_StructValue{StructValue: artifactStruct}},
+		},
+	}
+}
+
+func buildRecord(name, description, schemaVersion, version string, authors []*structpb.Value, module *structpb.Struct) *structpb.Struct {
+	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
 			"name":           {Kind: &structpb.Value_StringValue{StringValue: name}},
-			"schema_version": {Kind: &structpb.Value_StringValue{StringValue: targetVersion}},
-			"version":        {Kind: &structpb.Value_StringValue{StringValue: recordVersion}},
+			"schema_version": {Kind: &structpb.Value_StringValue{StringValue: schemaVersion}},
+			"version":        {Kind: &structpb.Value_StringValue{StringValue: version}},
 			"description":    {Kind: &structpb.Value_StringValue{StringValue: description}},
 			"authors": {
 				Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: authors}},
 			},
-			"created_at": {Kind: &structpb.Value_StringValue{StringValue: createdAt}},
+			"created_at": {Kind: &structpb.Value_StringValue{StringValue: time.Now().UTC().Format(time.RFC3339)}},
 			"skills": {
 				Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: []*structpb.Value{}}},
 			},
@@ -280,28 +306,39 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 				Kind: &structpb.Value_ListValue{
 					ListValue: &structpb.ListValue{
 						Values: []*structpb.Value{
-							{Kind: &structpb.Value_StructValue{StructValue: agentSkillsModule}},
+							{Kind: &structpb.Value_StructValue{StructValue: module}},
 						},
 					},
 				},
 			},
 		},
 	}
+}
 
-	return record, nil
+// skillMarkdownFields holds the parsed frontmatter fields from a SKILL.md file.
+type skillMarkdownFields struct {
+	name          string
+	description   string
+	license       string
+	compatibility string
+	allowedTools  []string
+	metadata      map[string]string
 }
 
 // parseSkillMarkdownContent parses a SKILL.md and returns its spec-defined frontmatter fields.
 // Spec frontmatter fields: name, description, license, compatibility, allowed-tools, metadata.
 // There is no top-level version field in the spec; version lives inside metadata.
-func parseSkillMarkdownContent(content string) (name, description, license, compatibility string, allowedTools []string, metadata map[string]string, err error) {
-	sections := strings.SplitN(content, "---", 3)
-	if len(sections) < 3 {
-		return "", "", "", "", nil, nil, errors.New("invalid SKILL.md: missing frontmatter delimiters")
+func parseSkillMarkdownContent(content string) (skillMarkdownFields, error) {
+	sections := strings.SplitN(content, "---", frontmatterParts)
+	if len(sections) < frontmatterMinParts {
+		return skillMarkdownFields{}, errors.New("invalid SKILL.md: missing frontmatter delimiters")
 	}
 
 	frontmatter := strings.TrimSpace(sections[1])
-	metadata = map[string]string{}
+
+	result := skillMarkdownFields{
+		metadata: map[string]string{},
+	}
 
 	lines := strings.Split(frontmatter, "\n")
 	for i := 0; i < len(lines); i++ {
@@ -319,7 +356,7 @@ func parseSkillMarkdownContent(content string) (name, description, license, comp
 
 				i++
 				k, v := splitYAMLKeyValue(strings.TrimSpace(next))
-				metadata[k] = v
+				result.metadata[k] = v
 			}
 
 			continue
@@ -328,28 +365,28 @@ func parseSkillMarkdownContent(content string) (name, description, license, comp
 		k, v := splitYAMLKeyValue(line)
 		switch k {
 		case "name":
-			name = v
+			result.name = v
 		case "description":
-			description = v
+			result.description = v
 		case "license":
-			license = v
+			result.license = v
 		case "compatibility":
-			compatibility = v
+			result.compatibility = v
 		case "allowed-tools":
-			allowedTools = strings.Fields(v)
+			result.allowedTools = strings.Fields(v)
 		}
 	}
 
-	if name == "" || description == "" {
-		return "", "", "", "", nil, nil, errors.New("SKILL.md must include name and description in frontmatter")
+	if result.name == "" || result.description == "" {
+		return skillMarkdownFields{}, errors.New("SKILL.md must include name and description in frontmatter")
 	}
 
-	return name, description, license, compatibility, allowedTools, metadata, nil
+	return result, nil
 }
 
 // splitYAMLKeyValue splits a YAML "key: value" line and unquotes quoted values.
 func splitYAMLKeyValue(line string) (string, string) {
-	parts := strings.SplitN(line, ":", 2)
+	parts := strings.SplitN(line, ":", yamlKeyValueParts)
 	key := strings.TrimSpace(parts[0])
 	value := ""
 

--- a/pkg/translator/agentskills.go
+++ b/pkg/translator/agentskills.go
@@ -10,10 +10,13 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	recordutil "github.com/agntcy/oasf-sdk/pkg/record"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+const AgentSkillsModuleName = "agentskills"
 
 // MarkdownOption configures the markdown output.
 type MarkdownOption func(*markdownOptions)
@@ -29,11 +32,26 @@ func WithBody(body string) MarkdownOption {
 	}
 }
 
-// BuildSkillMarkdown renders SKILL.md content from a manifest.
-// The manifest is expected to match the agentskills_manifest schema.
-func BuildSkillMarkdown(manifest *structpb.Struct, opts ...MarkdownOption) (string, error) {
+// RecordToSkillMarkdown renders SKILL.md content from a record containing the agentskills module.
+// The record must have an agentskills module with a skill_manifest field.
+func RecordToSkillMarkdown(record *structpb.Struct, opts ...MarkdownOption) (string, error) {
+	if record == nil {
+		return "", errors.New("record is nil")
+	}
+
+	found, moduleData := recordutil.GetModuleData(record, AgentSkillsModuleName)
+	if !found || moduleData == nil {
+		return "", errors.New("agentskills module not found in record")
+	}
+
+	manifestField := moduleData.GetFields()["skill_manifest"]
+	if manifestField == nil {
+		return "", errors.New("skill_manifest is missing")
+	}
+
+	manifest := manifestField.GetStructValue()
 	if manifest == nil {
-		return "", errors.New("manifest is nil")
+		return "", errors.New("skill_manifest is missing")
 	}
 
 	options := &markdownOptions{}
@@ -109,28 +127,229 @@ func BuildSkillMarkdown(manifest *structpb.Struct, opts ...MarkdownOption) (stri
 	return strings.Join(lines, "\n") + "\n", nil
 }
 
-// BuildSkillMarkdownFromRecord renders SKILL.md content from a record containing the agentskills module.
-func BuildSkillMarkdownFromRecord(record *structpb.Struct, opts ...MarkdownOption) (string, error) {
-	if record == nil {
-		return "", errors.New("record is nil")
+// SkillMarkdownToRecord converts a SKILL.md file content into an OASF-compliant record.
+// The input must be wrapped as {"skillMarkdown": "<content>"}.
+// Generates records using the specified schema version (via WithVersion option) or the default schema version.
+func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption) (*structpb.Struct, error) {
+	mdVal, ok := skillData.GetFields()["skillMarkdown"]
+	if !ok {
+		return nil, errors.New("missing 'skillMarkdown' in input data")
 	}
 
-	found, moduleData := recordutil.GetModuleData(record, "agentskills")
-	if !found || moduleData == nil {
-		return "", errors.New("agentskills module not found in record")
+	content := mdVal.GetStringValue()
+	if content == "" {
+		return nil, errors.New("'skillMarkdown' is empty")
 	}
 
-	manifestField := moduleData.GetFields()["skill_manifest"]
-	if manifestField == nil {
-		return "", errors.New("skill_manifest is missing")
+	name, description, version, license, compatibility, allowedTools, metadata, body, err := parseSkillMarkdownContent(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SKILL.md content: %w", err)
 	}
 
-	manifest := manifestField.GetStructValue()
-	if manifest == nil {
-		return "", errors.New("skill_manifest is missing")
+	recordName := name
+	if recordName == "" {
+		recordName = "generated-skill-agent"
 	}
 
-	return BuildSkillMarkdown(manifest, opts...)
+	recordDescription := description
+	if recordDescription == "" {
+		recordDescription = "Agent generated from SKILL.md"
+	}
+
+	recordVersion := version
+	if recordVersion == "" {
+		recordVersion = defaultVersion
+	}
+
+	createdAt := time.Now().UTC().Format(time.RFC3339)
+
+	// Build skill_manifest struct fields.
+	manifestFields := map[string]*structpb.Value{
+		"name": {Kind: &structpb.Value_StringValue{StringValue: name}},
+		"description": {Kind: &structpb.Value_StringValue{StringValue: description}},
+	}
+
+	if license != "" {
+		manifestFields["license"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: license}}
+	}
+
+	if compatibility != "" {
+		manifestFields["compatibility"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: compatibility}}
+	}
+
+	if version != "" {
+		manifestFields["version"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: version}}
+	}
+
+	if len(allowedTools) > 0 {
+		toolValues := make([]*structpb.Value, 0, len(allowedTools))
+		for _, tool := range allowedTools {
+			toolValues = append(toolValues, &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: tool}})
+		}
+
+		manifestFields["allowed_tools"] = &structpb.Value{
+			Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: toolValues}},
+		}
+	}
+
+	if len(metadata) > 0 {
+		metaFields := make(map[string]*structpb.Value, len(metadata))
+		for k, v := range metadata {
+			metaFields[k] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: v}}
+		}
+
+		manifestFields["frontmatter_metadata"] = &structpb.Value{
+			Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: metaFields}},
+		}
+	}
+
+	// Build module data.
+	moduleDataFields := map[string]*structpb.Value{
+		"skill_file": {Kind: &structpb.Value_StringValue{StringValue: "SKILL.md"}},
+		"skill_manifest": {
+			Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: manifestFields}},
+		},
+	}
+
+	if body != "" {
+		moduleDataFields["skill_body"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: body}}
+	}
+
+	moduleData := &structpb.Struct{Fields: moduleDataFields}
+
+	agentSkillsModule := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"name": {Kind: &structpb.Value_StringValue{StringValue: AgentSkillsModuleName}},
+			"data": {Kind: &structpb.Value_StructValue{StructValue: moduleData}},
+		},
+	}
+
+	// Determine target schema version.
+	options := &translatorOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	targetVersion := DefaultSchemaVersion
+	if options.version != "" {
+		if err := validateMajorVersion(options.version); err != nil {
+			return nil, err
+		}
+
+		targetVersion = options.version
+	}
+
+	record := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"name":           {Kind: &structpb.Value_StringValue{StringValue: recordName}},
+			"schema_version": {Kind: &structpb.Value_StringValue{StringValue: targetVersion}},
+			"version":        {Kind: &structpb.Value_StringValue{StringValue: recordVersion}},
+			"description":    {Kind: &structpb.Value_StringValue{StringValue: recordDescription}},
+			"authors": {
+				Kind: &structpb.Value_ListValue{
+					ListValue: &structpb.ListValue{Values: []*structpb.Value{}},
+				},
+			},
+			"created_at": {Kind: &structpb.Value_StringValue{StringValue: createdAt}},
+			"skills": {
+				Kind: &structpb.Value_ListValue{
+					ListValue: &structpb.ListValue{Values: []*structpb.Value{}},
+				},
+			},
+			"domains": {
+				Kind: &structpb.Value_ListValue{
+					ListValue: &structpb.ListValue{Values: []*structpb.Value{}},
+				},
+			},
+			"modules": {
+				Kind: &structpb.Value_ListValue{
+					ListValue: &structpb.ListValue{
+						Values: []*structpb.Value{
+							{Kind: &structpb.Value_StructValue{StructValue: agentSkillsModule}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return record, nil
+}
+
+// parseSkillMarkdownContent parses a SKILL.md file and returns its components.
+func parseSkillMarkdownContent(content string) (name, description, version, license, compatibility string, allowedTools []string, metadata map[string]string, body string, err error) {
+	sections := strings.SplitN(content, "---", 3)
+	if len(sections) < 3 {
+		return "", "", "", "", "", nil, nil, "", errors.New("invalid SKILL.md: missing frontmatter delimiters")
+	}
+
+	frontmatter := strings.TrimSpace(sections[1])
+	body = strings.TrimSpace(sections[2])
+	metadata = map[string]string{}
+
+	lines := strings.Split(frontmatter, "\n")
+	for i := 0; i < len(lines); i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+
+		if line == "metadata:" {
+			for i+1 < len(lines) {
+				next := lines[i+1]
+				if !strings.HasPrefix(next, "  ") {
+					break
+				}
+
+				i++
+				k, v := splitYAMLKeyValue(strings.TrimSpace(next))
+				metadata[k] = v
+			}
+
+			continue
+		}
+
+		k, v := splitYAMLKeyValue(line)
+		switch k {
+		case "name":
+			name = v
+		case "description":
+			description = v
+		case "license":
+			license = v
+		case "compatibility":
+			compatibility = v
+		case "version":
+			version = v
+		case "allowed-tools":
+			allowedTools = strings.Fields(v)
+		}
+	}
+
+	if name == "" || description == "" {
+		return "", "", "", "", "", nil, nil, "", errors.New("SKILL.md must include name and description in frontmatter")
+	}
+
+	return name, description, version, license, compatibility, allowedTools, metadata, body, nil
+}
+
+// splitYAMLKeyValue splits a YAML "key: value" line.
+func splitYAMLKeyValue(line string) (string, string) {
+	parts := strings.SplitN(line, ":", 2)
+	key := strings.TrimSpace(parts[0])
+	value := ""
+
+	if len(parts) > 1 {
+		value = strings.TrimSpace(parts[1])
+	}
+
+	if strings.HasPrefix(value, "\"") {
+		if unquoted, err := strconv.Unquote(value); err == nil {
+			value = unquoted
+		}
+	}
+
+	return key, value
 }
 
 func getString(data map[string]any, key string) string {

--- a/pkg/translator/agentskills.go
+++ b/pkg/translator/agentskills.go
@@ -4,6 +4,8 @@
 package translator
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"maps"
@@ -16,14 +18,19 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-const AgentSkillsModuleName = "agentskills"
+const agentSkillsMediaType = "application/agent-skills+md"
 
-// RecordToSkillMarkdown renders a spec-compliant SKILL.md from a record containing
-// the agentskills module. The body is read from the skill_body field in the module data.
+const (
+	AgentSkillsModuleName = "core/language_model/agentskills"
+	agentSkillsModuleID   = 10302
+)
+
+// RecordToSkillMarkdown returns the full SKILL.md content for a record containing
+// the agentskills module (name: "core/language_model/agentskills").
 //
-// The SKILL.md frontmatter contains exactly the fields defined by the Agent Skills
-// specification: name, description, license, compatibility, metadata, and allowed-tools.
-// There is no top-level version field in the spec; version belongs inside metadata.
+// If the module has an artifact with base64-encoded data, the original SKILL.md
+// (including its body) is decoded and returned directly. Otherwise the SKILL.md
+// is reconstructed from the stored manifest (frontmatter only, no body).
 func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 	if record == nil {
 		return "", errors.New("record is nil")
@@ -32,6 +39,16 @@ func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 	found, moduleData := recordutil.GetModuleData(record, AgentSkillsModuleName)
 	if !found || moduleData == nil {
 		return "", errors.New("agentskills module not found in record")
+	}
+
+	// Prefer returning the full original SKILL.md from the artifact when available.
+	if artifactData := getArtifactData(record, AgentSkillsModuleName); artifactData != "" {
+		decoded, err := base64.StdEncoding.DecodeString(artifactData)
+		if err != nil {
+			return "", fmt.Errorf("failed to decode artifact data: %w", err)
+		}
+
+		return string(decoded), nil
 	}
 
 	manifestField := moduleData.GetFields()["skill_manifest"]
@@ -53,9 +70,21 @@ func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 	}
 
 	license := getString(manifestMap, "license")
-	compatibility := getString(manifestMap, "compatibility")
+	// version is stored in the manifest for the record but is NOT a spec frontmatter field;
+	// surface it back under metadata.version so the SKILL.md stays spec-compliant.
+	version := getString(manifestMap, "version")
+	// compatibility is stored as []string in the schema; join with ", " for the SKILL.md scalar.
+	compatibilityItems := getStringSlice(manifestMap, "compatibility")
+	compatibility := strings.Join(compatibilityItems, ", ")
 	allowedTools := getStringSlice(manifestMap, "allowed_tools")
 	metadata := getStringMap(manifestMap, "frontmatter_metadata")
+
+	// Ensure version appears in metadata (not as a top-level frontmatter key per spec).
+	if version != "" {
+		if _, ok := metadata["version"]; !ok {
+			metadata["version"] = version
+		}
+	}
 
 	lines := []string{"---"}
 	lines = append(lines, "name: "+yamlScalar(name))
@@ -89,14 +118,7 @@ func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 	}
 
 	lines = append(lines, "---")
-
-	// Read body from skill_body in module data.
-	body := strings.TrimSpace(moduleData.GetFields()["skill_body"].GetStringValue())
-	if body != "" {
-		lines = append(lines, "", body)
-	} else {
-		lines = append(lines, "")
-	}
+	lines = append(lines, "")
 
 	return strings.Join(lines, "\n") + "\n", nil
 }
@@ -105,9 +127,8 @@ func RecordToSkillMarkdown(record *structpb.Struct) (string, error) {
 // The input must be wrapped as {"skillMarkdown": "<content>"}.
 // Generates records using the specified schema version (via WithVersion option) or the default schema version.
 //
-// The spec-defined frontmatter fields are: name, description, license, compatibility,
-// metadata, and allowed-tools. There is no top-level version field; version should live
-// inside metadata if needed.
+// The SKILL.md body is not stored in the record because the agentskills_data schema
+// has no field for it. Only the frontmatter fields are persisted.
 func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption) (*structpb.Struct, error) {
 	mdVal, ok := skillData.GetFields()["skillMarkdown"]
 	if !ok {
@@ -119,15 +140,18 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 		return nil, errors.New("'skillMarkdown' is empty")
 	}
 
-	name, description, license, compatibility, allowedTools, metadata, body, err := parseSkillMarkdownContent(content)
+	name, description, license, compatibility, allowedTools, metadata, err := parseSkillMarkdownContent(content)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SKILL.md content: %w", err)
 	}
 
-	// Derive record-level version from metadata["version"] if present, else use default.
+	// version is not a spec frontmatter field; source it from metadata["version"].
+	version := metadata["version"]
+
+	// Derive record-level version from metadata["version"], else default.
 	recordVersion := defaultVersion
-	if v, ok := metadata["version"]; ok && v != "" {
-		recordVersion = v
+	if version != "" {
+		recordVersion = version
 	}
 
 	// Derive authors from metadata["author"] if present.
@@ -140,7 +164,7 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 
 	createdAt := time.Now().UTC().Format(time.RFC3339)
 
-	// Build skill_manifest struct fields using only spec-defined frontmatter keys.
+	// Build skill_manifest fields matching the agentskills_manifest schema.
 	manifestFields := map[string]*structpb.Value{
 		"name":        {Kind: &structpb.Value_StringValue{StringValue: name}},
 		"description": {Kind: &structpb.Value_StringValue{StringValue: description}},
@@ -150,8 +174,21 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 		manifestFields["license"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: license}}
 	}
 
+	if version != "" {
+		manifestFields["version"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: version}}
+	}
+
+	// compatibility is array of string in the schema; store as a single-element array.
 	if compatibility != "" {
-		manifestFields["compatibility"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: compatibility}}
+		manifestFields["compatibility"] = &structpb.Value{
+			Kind: &structpb.Value_ListValue{
+				ListValue: &structpb.ListValue{
+					Values: []*structpb.Value{
+						{Kind: &structpb.Value_StringValue{StringValue: compatibility}},
+					},
+				},
+			},
+		}
 	}
 
 	if len(allowedTools) > 0 {
@@ -176,7 +213,7 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 		}
 	}
 
-	// Build module data.
+	// Build agentskills_data (only schema-defined fields: skill_file, skill_manifest).
 	moduleDataFields := map[string]*structpb.Value{
 		"skill_file": {Kind: &structpb.Value_StringValue{StringValue: "SKILL.md"}},
 		"skill_manifest": {
@@ -184,14 +221,27 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 		},
 	}
 
-	if body != "" {
-		moduleDataFields["skill_body"] = &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: body}}
+	// Build module.artifact: store the full SKILL.md (including body) as base64-encoded data.
+	contentBytes := []byte(content)
+	encoded := base64.StdEncoding.EncodeToString(contentBytes)
+	sum := sha256.Sum256(contentBytes)
+	digest := fmt.Sprintf("sha256:%x", sum)
+
+	artifactStruct := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"media_type": {Kind: &structpb.Value_StringValue{StringValue: agentSkillsMediaType}},
+			"size":       {Kind: &structpb.Value_NumberValue{NumberValue: float64(len(contentBytes))}},
+			"digest":     {Kind: &structpb.Value_StringValue{StringValue: digest}},
+			"data":       {Kind: &structpb.Value_StringValue{StringValue: encoded}},
+		},
 	}
 
 	agentSkillsModule := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"name": {Kind: &structpb.Value_StringValue{StringValue: AgentSkillsModuleName}},
-			"data": {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: moduleDataFields}}},
+			"name":     {Kind: &structpb.Value_StringValue{StringValue: AgentSkillsModuleName}},
+			"id":       {Kind: &structpb.Value_NumberValue{NumberValue: agentSkillsModuleID}},
+			"data":     {Kind: &structpb.Value_StructValue{StructValue: &structpb.Struct{Fields: moduleDataFields}}},
+			"artifact": {Kind: &structpb.Value_StructValue{StructValue: artifactStruct}},
 		},
 	}
 
@@ -241,17 +291,16 @@ func SkillMarkdownToRecord(skillData *structpb.Struct, opts ...TranslatorOption)
 	return record, nil
 }
 
-// parseSkillMarkdownContent parses a SKILL.md and returns its spec-defined components.
-// Spec fields: name, description, license, compatibility, allowed-tools, metadata.
-// There is no top-level version field in the spec.
-func parseSkillMarkdownContent(content string) (name, description, license, compatibility string, allowedTools []string, metadata map[string]string, body string, err error) {
+// parseSkillMarkdownContent parses a SKILL.md and returns its spec-defined frontmatter fields.
+// Spec frontmatter fields: name, description, license, compatibility, allowed-tools, metadata.
+// There is no top-level version field in the spec; version lives inside metadata.
+func parseSkillMarkdownContent(content string) (name, description, license, compatibility string, allowedTools []string, metadata map[string]string, err error) {
 	sections := strings.SplitN(content, "---", 3)
 	if len(sections) < 3 {
-		return "", "", "", "", nil, nil, "", errors.New("invalid SKILL.md: missing frontmatter delimiters")
+		return "", "", "", "", nil, nil, errors.New("invalid SKILL.md: missing frontmatter delimiters")
 	}
 
 	frontmatter := strings.TrimSpace(sections[1])
-	body = strings.TrimSpace(sections[2])
 	metadata = map[string]string{}
 
 	lines := strings.Split(frontmatter, "\n")
@@ -292,10 +341,10 @@ func parseSkillMarkdownContent(content string) (name, description, license, comp
 	}
 
 	if name == "" || description == "" {
-		return "", "", "", "", nil, nil, "", errors.New("SKILL.md must include name and description in frontmatter")
+		return "", "", "", "", nil, nil, errors.New("SKILL.md must include name and description in frontmatter")
 	}
 
-	return name, description, license, compatibility, allowedTools, metadata, body, nil
+	return name, description, license, compatibility, allowedTools, metadata, nil
 }
 
 // splitYAMLKeyValue splits a YAML "key: value" line and unquotes quoted values.
@@ -389,4 +438,33 @@ func yamlScalar(value string) string {
 	}
 
 	return value
+}
+
+// getArtifactData returns the base64-encoded artifact data string from the named module,
+// or empty string if absent.
+func getArtifactData(record *structpb.Struct, moduleName string) string {
+	modulesVal, ok := record.GetFields()["modules"]
+	if !ok {
+		return ""
+	}
+
+	for _, modVal := range modulesVal.GetListValue().GetValues() {
+		mod := modVal.GetStructValue()
+		if mod == nil {
+			continue
+		}
+
+		if mod.GetFields()["name"].GetStringValue() != moduleName {
+			continue
+		}
+
+		artifact := mod.GetFields()["artifact"].GetStructValue()
+		if artifact == nil {
+			return ""
+		}
+
+		return artifact.GetFields()["data"].GetStringValue()
+	}
+
+	return ""
 }

--- a/pkg/translator/agentskills_test.go
+++ b/pkg/translator/agentskills_test.go
@@ -10,7 +10,35 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestBuildSkillMarkdown(t *testing.T) {
+func buildAgentSkillsRecord(t *testing.T, manifestMap map[string]any, body string) *structpb.Struct {
+	t.Helper()
+
+	manifestStruct, err := structpb.NewStruct(manifestMap)
+	if err != nil {
+		t.Fatalf("Failed to build manifest struct: %v", err)
+	}
+
+	record, err := structpb.NewStruct(map[string]any{
+		"schema_version": "1.0.0",
+		"modules": []any{
+			map[string]any{
+				"name": AgentSkillsModuleName,
+				"data": map[string]any{
+					"skill_file":     "SKILL.md",
+					"skill_manifest": manifestStruct.AsMap(),
+					"skill_body":     body,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to build record struct: %v", err)
+	}
+
+	return record
+}
+
+func TestRecordToSkillMarkdown(t *testing.T) {
 	manifestMap := map[string]any{
 		"name":          "pdf-processing",
 		"description":   "Extract PDF text and merge files.",
@@ -23,14 +51,11 @@ func TestBuildSkillMarkdown(t *testing.T) {
 		},
 	}
 
-	manifestStruct, err := structpb.NewStruct(manifestMap)
-	if err != nil {
-		t.Fatalf("Failed to build manifest struct: %v", err)
-	}
+	record := buildAgentSkillsRecord(t, manifestMap, "Use this skill when handling PDFs.")
 
-	markdown, err := BuildSkillMarkdown(manifestStruct, WithBody("Use this skill when handling PDFs."))
+	markdown, err := RecordToSkillMarkdown(record, WithBody("Use this skill when handling PDFs."))
 	if err != nil {
-		t.Fatalf("BuildSkillMarkdown() error: %v", err)
+		t.Fatalf("RecordToSkillMarkdown() error: %v", err)
 	}
 
 	if !strings.Contains(markdown, "name: pdf-processing") {
@@ -54,7 +79,7 @@ func TestBuildSkillMarkdown(t *testing.T) {
 	}
 
 	if !strings.Contains(markdown, "version: 1.0.0") {
-		t.Fatalf("Expected version included in metadata")
+		t.Fatalf("Expected version included")
 	}
 
 	if !strings.Contains(markdown, "Use this skill when handling PDFs.") {
@@ -62,16 +87,157 @@ func TestBuildSkillMarkdown(t *testing.T) {
 	}
 }
 
-func TestBuildSkillMarkdownMissingFields(t *testing.T) {
-	manifestStruct, err := structpb.NewStruct(map[string]any{
+func TestRecordToSkillMarkdownMissingFields(t *testing.T) {
+	record := buildAgentSkillsRecord(t, map[string]any{
 		"name": "missing-description",
-	})
-	if err != nil {
-		t.Fatalf("Failed to build manifest struct: %v", err)
-	}
+	}, "")
 
-	_, err = BuildSkillMarkdown(manifestStruct)
+	_, err := RecordToSkillMarkdown(record)
 	if err == nil {
 		t.Fatalf("Expected error when description is missing")
 	}
+}
+
+func TestRecordToSkillMarkdownNoModule(t *testing.T) {
+	record, err := structpb.NewStruct(map[string]any{
+		"schema_version": "1.0.0",
+		"modules":        []any{},
+	})
+	if err != nil {
+		t.Fatalf("Failed to build record struct: %v", err)
+	}
+
+	_, err = RecordToSkillMarkdown(record)
+	if err == nil {
+		t.Fatalf("Expected error when agentskills module is missing")
+	}
+}
+
+func TestSkillMarkdownToRecord(t *testing.T) {
+	skillMD := `---
+name: pdf-processing
+description: Extract PDF text and merge files.
+license: Apache-2.0
+compatibility: Requires python3
+version: 1.0.0
+allowed-tools: Read Bash(jq:*)
+metadata:
+  author: example-org
+---
+Use this skill when handling PDFs.
+`
+
+	input, err := structpb.NewStruct(map[string]any{
+		"skillMarkdown": skillMD,
+	})
+	if err != nil {
+		t.Fatalf("Failed to build input struct: %v", err)
+	}
+
+	record, err := SkillMarkdownToRecord(input)
+	if err != nil {
+		t.Fatalf("SkillMarkdownToRecord() error: %v", err)
+	}
+
+	if record == nil {
+		t.Fatalf("Expected non-nil record")
+	}
+
+	// Verify top-level fields.
+	fields := record.GetFields()
+	if fields["name"].GetStringValue() != "pdf-processing" {
+		t.Errorf("Expected record name 'pdf-processing', got %q", fields["name"].GetStringValue())
+	}
+
+	if fields["description"].GetStringValue() != "Extract PDF text and merge files." {
+		t.Errorf("Expected record description, got %q", fields["description"].GetStringValue())
+	}
+
+	if fields["version"].GetStringValue() != "1.0.0" {
+		t.Errorf("Expected record version '1.0.0', got %q", fields["version"].GetStringValue())
+	}
+
+	// Verify agentskills module.
+	found, moduleData := findModule(record, AgentSkillsModuleName)
+	if !found || moduleData == nil {
+		t.Fatalf("Expected agentskills module in record")
+	}
+
+	manifestVal := moduleData.GetFields()["skill_manifest"]
+	if manifestVal == nil {
+		t.Fatalf("Expected skill_manifest in module data")
+	}
+
+	manifest := manifestVal.GetStructValue()
+	if manifest == nil {
+		t.Fatalf("Expected skill_manifest to be a struct")
+	}
+
+	manifestFields := manifest.GetFields()
+
+	if manifestFields["name"].GetStringValue() != "pdf-processing" {
+		t.Errorf("Expected manifest name 'pdf-processing'")
+	}
+
+	if manifestFields["license"].GetStringValue() != "Apache-2.0" {
+		t.Errorf("Expected manifest license 'Apache-2.0'")
+	}
+
+	if manifestFields["version"].GetStringValue() != "1.0.0" {
+		t.Errorf("Expected manifest version '1.0.0'")
+	}
+}
+
+func TestSkillMarkdownToRecordMissingName(t *testing.T) {
+	skillMD := `---
+description: Only description, no name.
+---
+`
+
+	input, err := structpb.NewStruct(map[string]any{
+		"skillMarkdown": skillMD,
+	})
+	if err != nil {
+		t.Fatalf("Failed to build input: %v", err)
+	}
+
+	_, err = SkillMarkdownToRecord(input)
+	if err == nil {
+		t.Fatalf("Expected error for missing name")
+	}
+}
+
+func TestSkillMarkdownToRecordMissingWrapper(t *testing.T) {
+	input, err := structpb.NewStruct(map[string]any{
+		"notSkillMarkdown": "---\nname: x\ndescription: y\n---\n",
+	})
+	if err != nil {
+		t.Fatalf("Failed to build input: %v", err)
+	}
+
+	_, err = SkillMarkdownToRecord(input)
+	if err == nil {
+		t.Fatalf("Expected error for missing 'skillMarkdown' key")
+	}
+}
+
+// findModule is a test helper to locate a named module in a record's modules list.
+func findModule(record *structpb.Struct, name string) (bool, *structpb.Struct) {
+	modulesVal, ok := record.GetFields()["modules"]
+	if !ok {
+		return false, nil
+	}
+
+	for _, modVal := range modulesVal.GetListValue().GetValues() {
+		mod := modVal.GetStructValue()
+		if mod == nil {
+			continue
+		}
+
+		if mod.GetFields()["name"].GetStringValue() == name {
+			return true, mod.GetFields()["data"].GetStructValue()
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/translator/agentskills_test.go
+++ b/pkg/translator/agentskills_test.go
@@ -10,6 +10,8 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+// buildAgentSkillsRecord constructs a minimal OASF record with an agentskills module
+// containing the provided manifest fields and body.
 func buildAgentSkillsRecord(t *testing.T, manifestMap map[string]any, body string) *structpb.Struct {
 	t.Helper()
 
@@ -18,16 +20,20 @@ func buildAgentSkillsRecord(t *testing.T, manifestMap map[string]any, body strin
 		t.Fatalf("Failed to build manifest struct: %v", err)
 	}
 
+	moduleData := map[string]any{
+		"skill_file":     "SKILL.md",
+		"skill_manifest": manifestStruct.AsMap(),
+	}
+	if body != "" {
+		moduleData["skill_body"] = body
+	}
+
 	record, err := structpb.NewStruct(map[string]any{
 		"schema_version": "1.0.0",
 		"modules": []any{
 			map[string]any{
 				"name": AgentSkillsModuleName,
-				"data": map[string]any{
-					"skill_file":     "SKILL.md",
-					"skill_manifest": manifestStruct.AsMap(),
-					"skill_body":     body,
-				},
+				"data": moduleData,
 			},
 		},
 	})
@@ -39,55 +45,57 @@ func buildAgentSkillsRecord(t *testing.T, manifestMap map[string]any, body strin
 }
 
 func TestRecordToSkillMarkdown(t *testing.T) {
+	// Spec fields only: name, description, license, compatibility, allowed-tools, metadata.
+	// version lives inside metadata, not as a top-level frontmatter key.
 	manifestMap := map[string]any{
 		"name":          "pdf-processing",
 		"description":   "Extract PDF text and merge files.",
 		"license":       "Apache-2.0",
 		"compatibility": "Requires python3",
-		"version":       "1.0.0",
 		"allowed_tools": []any{"Read", "Bash(jq:*)"},
 		"frontmatter_metadata": map[string]any{
-			"author": "example-org",
+			"author":  "example-org",
+			"version": "1.0",
 		},
 	}
 
 	record := buildAgentSkillsRecord(t, manifestMap, "Use this skill when handling PDFs.")
 
-	markdown, err := RecordToSkillMarkdown(record, WithBody("Use this skill when handling PDFs."))
+	markdown, err := RecordToSkillMarkdown(record)
 	if err != nil {
 		t.Fatalf("RecordToSkillMarkdown() error: %v", err)
 	}
 
-	if !strings.Contains(markdown, "name: pdf-processing") {
-		t.Fatalf("Expected name in frontmatter")
+	checks := []struct {
+		contains bool
+		fragment string
+		label    string
+	}{
+		{true, "name: pdf-processing", "name"},
+		{true, "description: Extract PDF text and merge files.", "description"},
+		{true, "license: Apache-2.0", "license"},
+		{true, "compatibility: Requires python3", "compatibility"},
+		{true, "allowed-tools: Read Bash(jq:*)", "allowed-tools"},
+		{true, "metadata:", "metadata section"},
+		{true, "author: example-org", "metadata author"},
+		{true, "version: 1.0", "metadata version"},
+		{false, "\nversion: ", "no top-level version key"},
+		{true, "Use this skill when handling PDFs.", "body"},
 	}
 
-	if !strings.Contains(markdown, "description: Extract PDF text and merge files.") {
-		t.Fatalf("Expected description in frontmatter")
-	}
-
-	if !strings.Contains(markdown, "license: Apache-2.0") {
-		t.Fatalf("Expected license in frontmatter")
-	}
-
-	if !strings.Contains(markdown, "allowed-tools: Read Bash(jq:*)") {
-		t.Fatalf("Expected allowed-tools in frontmatter")
-	}
-
-	if !strings.Contains(markdown, "metadata:") {
-		t.Fatalf("Expected metadata section")
-	}
-
-	if !strings.Contains(markdown, "version: 1.0.0") {
-		t.Fatalf("Expected version included")
-	}
-
-	if !strings.Contains(markdown, "Use this skill when handling PDFs.") {
-		t.Fatalf("Expected body content")
+	for _, c := range checks {
+		got := strings.Contains(markdown, c.fragment)
+		if got != c.contains {
+			if c.contains {
+				t.Errorf("Expected %s in output, not found.\nmarkdown:\n%s", c.label, markdown)
+			} else {
+				t.Errorf("Expected %s NOT in output, but found it.\nmarkdown:\n%s", c.label, markdown)
+			}
+		}
 	}
 }
 
-func TestRecordToSkillMarkdownMissingFields(t *testing.T) {
+func TestRecordToSkillMarkdownMissingDescription(t *testing.T) {
 	record := buildAgentSkillsRecord(t, map[string]any{
 		"name": "missing-description",
 	}, "")
@@ -114,15 +122,16 @@ func TestRecordToSkillMarkdownNoModule(t *testing.T) {
 }
 
 func TestSkillMarkdownToRecord(t *testing.T) {
+	// version is inside metadata per spec, not a top-level frontmatter key.
 	skillMD := `---
 name: pdf-processing
 description: Extract PDF text and merge files.
 license: Apache-2.0
 compatibility: Requires python3
-version: 1.0.0
 allowed-tools: Read Bash(jq:*)
 metadata:
   author: example-org
+  version: "1.0"
 ---
 Use this skill when handling PDFs.
 `
@@ -139,63 +148,86 @@ Use this skill when handling PDFs.
 		t.Fatalf("SkillMarkdownToRecord() error: %v", err)
 	}
 
-	if record == nil {
-		t.Fatalf("Expected non-nil record")
-	}
-
-	// Verify top-level fields.
 	fields := record.GetFields()
+
 	if fields["name"].GetStringValue() != "pdf-processing" {
 		t.Errorf("Expected record name 'pdf-processing', got %q", fields["name"].GetStringValue())
 	}
 
-	if fields["description"].GetStringValue() != "Extract PDF text and merge files." {
-		t.Errorf("Expected record description, got %q", fields["description"].GetStringValue())
+	// Record version should be derived from metadata["version"].
+	if fields["version"].GetStringValue() != "1.0" {
+		t.Errorf("Expected record version '1.0', got %q", fields["version"].GetStringValue())
 	}
 
-	if fields["version"].GetStringValue() != "1.0.0" {
-		t.Errorf("Expected record version '1.0.0', got %q", fields["version"].GetStringValue())
+	// Record authors should be derived from metadata["author"].
+	authorVals := fields["authors"].GetListValue().GetValues()
+	if len(authorVals) != 1 || authorVals[0].GetStringValue() != "example-org" {
+		t.Errorf("Expected authors = [\"example-org\"], got %v", authorVals)
 	}
 
-	// Verify agentskills module.
 	found, moduleData := findModule(record, AgentSkillsModuleName)
 	if !found || moduleData == nil {
 		t.Fatalf("Expected agentskills module in record")
 	}
 
-	manifestVal := moduleData.GetFields()["skill_manifest"]
-	if manifestVal == nil {
-		t.Fatalf("Expected skill_manifest in module data")
-	}
-
-	manifest := manifestVal.GetStructValue()
+	manifest := moduleData.GetFields()["skill_manifest"].GetStructValue()
 	if manifest == nil {
 		t.Fatalf("Expected skill_manifest to be a struct")
 	}
 
-	manifestFields := manifest.GetFields()
+	mf := manifest.GetFields()
 
-	if manifestFields["name"].GetStringValue() != "pdf-processing" {
+	if mf["name"].GetStringValue() != "pdf-processing" {
 		t.Errorf("Expected manifest name 'pdf-processing'")
 	}
 
-	if manifestFields["license"].GetStringValue() != "Apache-2.0" {
+	if mf["license"].GetStringValue() != "Apache-2.0" {
 		t.Errorf("Expected manifest license 'Apache-2.0'")
 	}
 
-	if manifestFields["version"].GetStringValue() != "1.0.0" {
-		t.Errorf("Expected manifest version '1.0.0'")
+	// version must NOT appear as a top-level manifest field.
+	if _, hasVersion := mf["version"]; hasVersion {
+		t.Errorf("version must not be a top-level manifest field per spec; it belongs in frontmatter_metadata")
+	}
+
+	// version must be in frontmatter_metadata.
+	meta := mf["frontmatter_metadata"].GetStructValue()
+	if meta == nil {
+		t.Fatalf("Expected frontmatter_metadata struct")
+	}
+
+	if meta.GetFields()["version"].GetStringValue() != "1.0" {
+		t.Errorf("Expected frontmatter_metadata.version = '1.0'")
+	}
+}
+
+func TestSkillMarkdownToRecordNoVersionInMetadata(t *testing.T) {
+	skillMD := `---
+name: simple-skill
+description: A simple skill with no version.
+---
+Do something useful.
+`
+
+	input, err := structpb.NewStruct(map[string]any{"skillMarkdown": skillMD})
+	if err != nil {
+		t.Fatalf("Failed to build input: %v", err)
+	}
+
+	record, err := SkillMarkdownToRecord(input)
+	if err != nil {
+		t.Fatalf("SkillMarkdownToRecord() error: %v", err)
+	}
+
+	// Should fall back to defaultVersion.
+	if record.GetFields()["version"].GetStringValue() != defaultVersion {
+		t.Errorf("Expected default version %q when metadata has no version", defaultVersion)
 	}
 }
 
 func TestSkillMarkdownToRecordMissingName(t *testing.T) {
-	skillMD := `---
-description: Only description, no name.
----
-`
-
 	input, err := structpb.NewStruct(map[string]any{
-		"skillMarkdown": skillMD,
+		"skillMarkdown": "---\ndescription: Only description, no name.\n---\n",
 	})
 	if err != nil {
 		t.Fatalf("Failed to build input: %v", err)

--- a/pkg/translator/agentskills_test.go
+++ b/pkg/translator/agentskills_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 // buildAgentSkillsRecord constructs a minimal OASF record with an agentskills module
-// containing the provided manifest fields and body.
-func buildAgentSkillsRecord(t *testing.T, manifestMap map[string]any, body string) *structpb.Struct {
+// containing the provided manifest fields. No skill_body — it is not in the schema.
+func buildAgentSkillsRecord(t *testing.T, manifestMap map[string]any) *structpb.Struct {
 	t.Helper()
 
 	manifestStruct, err := structpb.NewStruct(manifestMap)
@@ -20,20 +20,16 @@ func buildAgentSkillsRecord(t *testing.T, manifestMap map[string]any, body strin
 		t.Fatalf("Failed to build manifest struct: %v", err)
 	}
 
-	moduleData := map[string]any{
-		"skill_file":     "SKILL.md",
-		"skill_manifest": manifestStruct.AsMap(),
-	}
-	if body != "" {
-		moduleData["skill_body"] = body
-	}
-
 	record, err := structpb.NewStruct(map[string]any{
 		"schema_version": "1.0.0",
 		"modules": []any{
 			map[string]any{
 				"name": AgentSkillsModuleName,
-				"data": moduleData,
+				"id":   agentSkillsModuleID,
+				"data": map[string]any{
+					"skill_file":     "SKILL.md",
+					"skill_manifest": manifestStruct.AsMap(),
+				},
 			},
 		},
 	})
@@ -45,21 +41,19 @@ func buildAgentSkillsRecord(t *testing.T, manifestMap map[string]any, body strin
 }
 
 func TestRecordToSkillMarkdown(t *testing.T) {
-	// Spec fields only: name, description, license, compatibility, allowed-tools, metadata.
-	// version lives inside metadata, not as a top-level frontmatter key.
 	manifestMap := map[string]any{
 		"name":          "pdf-processing",
 		"description":   "Extract PDF text and merge files.",
 		"license":       "Apache-2.0",
-		"compatibility": "Requires python3",
+		"version":       "1.0",
+		"compatibility": []any{"Requires python3"},
 		"allowed_tools": []any{"Read", "Bash(jq:*)"},
 		"frontmatter_metadata": map[string]any{
-			"author":  "example-org",
-			"version": "1.0",
+			"author": "example-org",
 		},
 	}
 
-	record := buildAgentSkillsRecord(t, manifestMap, "Use this skill when handling PDFs.")
+	record := buildAgentSkillsRecord(t, manifestMap)
 
 	markdown, err := RecordToSkillMarkdown(record)
 	if err != nil {
@@ -74,22 +68,22 @@ func TestRecordToSkillMarkdown(t *testing.T) {
 		{true, "name: pdf-processing", "name"},
 		{true, "description: Extract PDF text and merge files.", "description"},
 		{true, "license: Apache-2.0", "license"},
-		{true, "compatibility: Requires python3", "compatibility"},
+		{true, "compatibility: Requires python3", "compatibility (joined)"},
 		{true, "allowed-tools: Read Bash(jq:*)", "allowed-tools"},
 		{true, "metadata:", "metadata section"},
 		{true, "author: example-org", "metadata author"},
-		{true, "version: 1.0", "metadata version"},
-		{false, "\nversion: ", "no top-level version key"},
-		{true, "Use this skill when handling PDFs.", "body"},
+		// version must appear in metadata, not as a top-level frontmatter key (per spec).
+		{true, "version: 1.0", "version in metadata"},
+		{false, "\nversion: 1.0\n", "version as top-level key (not allowed by spec)"},
 	}
 
 	for _, c := range checks {
 		got := strings.Contains(markdown, c.fragment)
 		if got != c.contains {
 			if c.contains {
-				t.Errorf("Expected %s in output, not found.\nmarkdown:\n%s", c.label, markdown)
+				t.Errorf("Expected %s in output.\nmarkdown:\n%s", c.label, markdown)
 			} else {
-				t.Errorf("Expected %s NOT in output, but found it.\nmarkdown:\n%s", c.label, markdown)
+				t.Errorf("Expected %s NOT in output.\nmarkdown:\n%s", c.label, markdown)
 			}
 		}
 	}
@@ -98,7 +92,7 @@ func TestRecordToSkillMarkdown(t *testing.T) {
 func TestRecordToSkillMarkdownMissingDescription(t *testing.T) {
 	record := buildAgentSkillsRecord(t, map[string]any{
 		"name": "missing-description",
-	}, "")
+	})
 
 	_, err := RecordToSkillMarkdown(record)
 	if err == nil {
@@ -122,7 +116,7 @@ func TestRecordToSkillMarkdownNoModule(t *testing.T) {
 }
 
 func TestSkillMarkdownToRecord(t *testing.T) {
-	// version is inside metadata per spec, not a top-level frontmatter key.
+	// version is NOT a top-level frontmatter key per the spec; it lives in metadata.
 	skillMD := `---
 name: pdf-processing
 description: Extract PDF text and merge files.
@@ -136,9 +130,7 @@ metadata:
 Use this skill when handling PDFs.
 `
 
-	input, err := structpb.NewStruct(map[string]any{
-		"skillMarkdown": skillMD,
-	})
+	input, err := structpb.NewStruct(map[string]any{"skillMarkdown": skillMD})
 	if err != nil {
 		t.Fatalf("Failed to build input struct: %v", err)
 	}
@@ -154,12 +146,12 @@ Use this skill when handling PDFs.
 		t.Errorf("Expected record name 'pdf-processing', got %q", fields["name"].GetStringValue())
 	}
 
-	// Record version should be derived from metadata["version"].
+	// version comes from metadata["version"].
 	if fields["version"].GetStringValue() != "1.0" {
 		t.Errorf("Expected record version '1.0', got %q", fields["version"].GetStringValue())
 	}
 
-	// Record authors should be derived from metadata["author"].
+	// authors derived from metadata.author.
 	authorVals := fields["authors"].GetListValue().GetValues()
 	if len(authorVals) != 1 || authorVals[0].GetStringValue() != "example-org" {
 		t.Errorf("Expected authors = [\"example-org\"], got %v", authorVals)
@@ -167,7 +159,7 @@ Use this skill when handling PDFs.
 
 	found, moduleData := findModule(record, AgentSkillsModuleName)
 	if !found || moduleData == nil {
-		t.Fatalf("Expected agentskills module in record")
+		t.Fatalf("Expected agentskills module %q in record", AgentSkillsModuleName)
 	}
 
 	manifest := moduleData.GetFields()["skill_manifest"].GetStructValue()
@@ -185,28 +177,29 @@ Use this skill when handling PDFs.
 		t.Errorf("Expected manifest license 'Apache-2.0'")
 	}
 
-	// version must NOT appear as a top-level manifest field.
-	if _, hasVersion := mf["version"]; hasVersion {
-		t.Errorf("version must not be a top-level manifest field per spec; it belongs in frontmatter_metadata")
+	// version is a top-level manifest field per the agentskills_manifest schema.
+	if mf["version"].GetStringValue() != "1.0" {
+		t.Errorf("Expected manifest version '1.0', got %q", mf["version"].GetStringValue())
 	}
 
-	// version must be in frontmatter_metadata.
-	meta := mf["frontmatter_metadata"].GetStructValue()
-	if meta == nil {
-		t.Fatalf("Expected frontmatter_metadata struct")
+	// compatibility must be stored as []string per the agentskills_manifest schema.
+	compatItems := mf["compatibility"].GetListValue().GetValues()
+	if len(compatItems) != 1 || compatItems[0].GetStringValue() != "Requires python3" {
+		t.Errorf("Expected compatibility = [\"Requires python3\"], got %v", compatItems)
 	}
 
-	if meta.GetFields()["version"].GetStringValue() != "1.0" {
-		t.Errorf("Expected frontmatter_metadata.version = '1.0'")
+	// skill_body must NOT be stored (not in agentskills_data schema).
+	if _, hasBody := moduleData.GetFields()["skill_body"]; hasBody {
+		t.Errorf("skill_body must not be stored in the record: not defined in agentskills_data schema")
 	}
 }
 
-func TestSkillMarkdownToRecordNoVersionInMetadata(t *testing.T) {
+func TestSkillMarkdownToRecordVersionFallback(t *testing.T) {
+	// No version in frontmatter and no version in metadata → defaultVersion.
 	skillMD := `---
 name: simple-skill
-description: A simple skill with no version.
+description: A simple skill.
 ---
-Do something useful.
 `
 
 	input, err := structpb.NewStruct(map[string]any{"skillMarkdown": skillMD})
@@ -219,9 +212,33 @@ Do something useful.
 		t.Fatalf("SkillMarkdownToRecord() error: %v", err)
 	}
 
-	// Should fall back to defaultVersion.
 	if record.GetFields()["version"].GetStringValue() != defaultVersion {
-		t.Errorf("Expected default version %q when metadata has no version", defaultVersion)
+		t.Errorf("Expected default version %q, got %q", defaultVersion, record.GetFields()["version"].GetStringValue())
+	}
+}
+
+func TestSkillMarkdownToRecordVersionFromMetadata(t *testing.T) {
+	// No top-level version → falls back to metadata["version"].
+	skillMD := `---
+name: simple-skill
+description: A simple skill.
+metadata:
+  version: "2.0"
+---
+`
+
+	input, err := structpb.NewStruct(map[string]any{"skillMarkdown": skillMD})
+	if err != nil {
+		t.Fatalf("Failed to build input: %v", err)
+	}
+
+	record, err := SkillMarkdownToRecord(input)
+	if err != nil {
+		t.Fatalf("SkillMarkdownToRecord() error: %v", err)
+	}
+
+	if record.GetFields()["version"].GetStringValue() != "2.0" {
+		t.Errorf("Expected version '2.0' from metadata, got %q", record.GetFields()["version"].GetStringValue())
 	}
 }
 

--- a/pkg/translator/agentskills_test.go
+++ b/pkg/translator/agentskills_test.go
@@ -140,6 +140,12 @@ Use this skill when handling PDFs.
 		t.Fatalf("SkillMarkdownToRecord() error: %v", err)
 	}
 
+	assertSkillRecord(t, record)
+}
+
+func assertSkillRecord(t *testing.T, record *structpb.Struct) {
+	t.Helper()
+
 	fields := record.GetFields()
 
 	if fields["name"].GetStringValue() != "pdf-processing" {
@@ -156,6 +162,12 @@ Use this skill when handling PDFs.
 	if len(authorVals) != 1 || authorVals[0].GetStringValue() != "example-org" {
 		t.Errorf("Expected authors = [\"example-org\"], got %v", authorVals)
 	}
+
+	assertSkillModule(t, record)
+}
+
+func assertSkillModule(t *testing.T, record *structpb.Struct) {
+	t.Helper()
 
 	found, moduleData := findModule(record, AgentSkillsModuleName)
 	if !found || moduleData == nil {

--- a/proto/agntcy/oasfsdk/translation/v1/translation_service.proto
+++ b/proto/agntcy/oasfsdk/translation/v1/translation_service.proto
@@ -23,6 +23,12 @@ service TranslationService {
 
   // MCPToRecord generates a Record from an MCP Registry entry.
   rpc MCPToRecord(MCPToRecordRequest) returns (MCPToRecordResponse);
+
+  // SkillMarkdownToRecord generates a Record from a SKILL.md file content.
+  rpc SkillMarkdownToRecord(SkillMarkdownToRecordRequest) returns (SkillMarkdownToRecordResponse);
+
+  // RecordToSkillMarkdown generates a SKILL.md file content from a Record.
+  rpc RecordToSkillMarkdown(RecordToSkillMarkdownRequest) returns (RecordToSkillMarkdownResponse);
 }
 
 message RecordToGHCopilotRequest {
@@ -73,4 +79,24 @@ message MCPToRecordRequest {
 message MCPToRecordResponse {
   // The generated Record object in a structured format.
   google.protobuf.Struct record = 1;
+}
+
+message SkillMarkdownToRecordRequest {
+  // The SKILL.md content wrapped as {"skillMarkdown": "<content>"} to be converted to a Record object.
+  google.protobuf.Struct data = 1;
+}
+
+message SkillMarkdownToRecordResponse {
+  // The generated Record object in a structured format.
+  google.protobuf.Struct record = 1;
+}
+
+message RecordToSkillMarkdownRequest {
+  // The Record object to be converted into SKILL.md content.
+  google.protobuf.Struct record = 1;
+}
+
+message RecordToSkillMarkdownResponse {
+  // The generated SKILL.md content as a plain string.
+  string data = 1;
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -13,7 +13,7 @@ require (
 )
 
 require (
-	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1 // indirect
+	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -4,6 +4,8 @@ buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260402143721-5fd9
 buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260402143721-5fd9f22378bc.1/go.mod h1:EEQp9sY+88ieMjKf9W4Uf9t3X6qV1nHY0DcGOxsMlac=
 buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1 h1:c5Knf+Ki5RRjRAZIK11brQyaI2On4lOvel/cNg4hnJc=
 buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1/go.mod h1:y7UzNChPK2OBXQxpwimQg6fSgSFLC1jZXTk9Y7HFfNc=
+buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1 h1:zG4FFqTORpGsQVx1fo5qjcYZbNZqk56B6y0986Nexzg=
+buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1/go.mod h1:y7UzNChPK2OBXQxpwimQg6fSgSFLC1jZXTk9Y7HFfNc=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/tests/embed_test.go
+++ b/tests/embed_test.go
@@ -85,3 +85,15 @@ var translationDirMCPRecord []byte
 
 //go:embed fixtures/expected_dir_mcp_gh_copilot_output.json
 var expectedDirMCPGHCopilotOutput []byte
+
+//go:embed fixtures/translation_skill.json
+var translationSkillMarkdown []byte
+
+//go:embed fixtures/expected_skilltorecord_output.json
+var expectedSkillToRecordOutput []byte
+
+//go:embed fixtures/translation_agentskills_record.json
+var translationAgentSkillsRecord []byte
+
+//go:embed fixtures/expected_recordtoskill_output.md
+var expectedRecordToSkillOutput []byte

--- a/tests/fixtures/expected_recordtoskill_output.md
+++ b/tests/fixtures/expected_recordtoskill_output.md
@@ -3,11 +3,10 @@ name: pdf-processing
 description: Extract PDF text and merge files. Use when handling PDFs.
 license: Apache-2.0
 compatibility: Requires python3
-version: 1.0.0
 allowed-tools: Read Bash(jq:*)
 metadata:
   author: example-org
-  version: 1.0.0
+  version: 1.0
 ---
 
 # PDF Processing Skill

--- a/tests/fixtures/expected_recordtoskill_output.md
+++ b/tests/fixtures/expected_recordtoskill_output.md
@@ -7,8 +7,9 @@ version: 1.0.0
 allowed-tools: Read Bash(jq:*)
 metadata:
   author: example-org
-  version: "1.0.0"
+  version: 1.0.0
 ---
+
 # PDF Processing Skill
 
 Use this skill when handling PDFs.

--- a/tests/fixtures/expected_recordtoskill_output.md
+++ b/tests/fixtures/expected_recordtoskill_output.md
@@ -6,9 +6,8 @@ compatibility: Requires python3
 allowed-tools: Read Bash(jq:*)
 metadata:
   author: example-org
-  version: 1.0
+  version: "1.0"
 ---
-
 # PDF Processing Skill
 
 Use this skill when handling PDFs.

--- a/tests/fixtures/expected_skilltorecord_output.json
+++ b/tests/fixtures/expected_skilltorecord_output.json
@@ -1,6 +1,8 @@
 {
   "_comment_created_at": "NOTE: This timestamp is dynamically generated. Test should be flexible about this field.",
-  "authors": [],
+  "authors": [
+    "example-org"
+  ],
   "created_at": "2025-01-01T00:00:00Z",
   "description": "Extract PDF text and merge files. Use when handling PDFs.",
   "domains": [],
@@ -18,11 +20,10 @@
           "description": "Extract PDF text and merge files. Use when handling PDFs.",
           "frontmatter_metadata": {
             "author": "example-org",
-            "version": "1.0.0"
+            "version": "1.0"
           },
           "license": "Apache-2.0",
-          "name": "pdf-processing",
-          "version": "1.0.0"
+          "name": "pdf-processing"
         }
       },
       "name": "agentskills"
@@ -31,5 +32,5 @@
   "name": "pdf-processing",
   "schema_version": "1.0.0",
   "skills": [],
-  "version": "1.0.0"
+  "version": "1.0"
 }

--- a/tests/fixtures/expected_skilltorecord_output.json
+++ b/tests/fixtures/expected_skilltorecord_output.json
@@ -8,25 +8,34 @@
   "domains": [],
   "modules": [
     {
+      "id": 10302,
+      "artifact": {
+        "data": "LS0tCm5hbWU6IHBkZi1wcm9jZXNzaW5nCmRlc2NyaXB0aW9uOiBFeHRyYWN0IFBERiB0ZXh0IGFuZCBtZXJnZSBmaWxlcy4gVXNlIHdoZW4gaGFuZGxpbmcgUERGcy4KbGljZW5zZTogQXBhY2hlLTIuMApjb21wYXRpYmlsaXR5OiBSZXF1aXJlcyBweXRob24zCmFsbG93ZWQtdG9vbHM6IFJlYWQgQmFzaChqcToqKQptZXRhZGF0YToKICBhdXRob3I6IGV4YW1wbGUtb3JnCiAgdmVyc2lvbjogIjEuMCIKLS0tCiMgUERGIFByb2Nlc3NpbmcgU2tpbGwKClVzZSB0aGlzIHNraWxsIHdoZW4gaGFuZGxpbmcgUERGcy4K",
+        "digest": "sha256:d5de35a17d15c7fca2d9793bf3c75976449d8d07a08064f2fe67477901c8de4d",
+        "media_type": "application/agent-skills+md",
+        "size": 291
+      },
       "data": {
-        "skill_body": "# PDF Processing Skill\n\nUse this skill when handling PDFs.",
         "skill_file": "SKILL.md",
         "skill_manifest": {
           "allowed_tools": [
             "Read",
             "Bash(jq:*)"
           ],
-          "compatibility": "Requires python3",
+          "compatibility": [
+            "Requires python3"
+          ],
           "description": "Extract PDF text and merge files. Use when handling PDFs.",
           "frontmatter_metadata": {
             "author": "example-org",
             "version": "1.0"
           },
           "license": "Apache-2.0",
-          "name": "pdf-processing"
+          "name": "pdf-processing",
+          "version": "1.0"
         }
       },
-      "name": "agentskills"
+      "name": "core/language_model/agentskills"
     }
   ],
   "name": "pdf-processing",

--- a/tests/fixtures/expected_skilltorecord_output.json
+++ b/tests/fixtures/expected_skilltorecord_output.json
@@ -1,0 +1,35 @@
+{
+  "_comment_created_at": "NOTE: This timestamp is dynamically generated. Test should be flexible about this field.",
+  "authors": [],
+  "created_at": "2025-01-01T00:00:00Z",
+  "description": "Extract PDF text and merge files. Use when handling PDFs.",
+  "domains": [],
+  "modules": [
+    {
+      "data": {
+        "skill_body": "# PDF Processing Skill\n\nUse this skill when handling PDFs.",
+        "skill_file": "SKILL.md",
+        "skill_manifest": {
+          "allowed_tools": [
+            "Read",
+            "Bash(jq:*)"
+          ],
+          "compatibility": "Requires python3",
+          "description": "Extract PDF text and merge files. Use when handling PDFs.",
+          "frontmatter_metadata": {
+            "author": "example-org",
+            "version": "1.0.0"
+          },
+          "license": "Apache-2.0",
+          "name": "pdf-processing",
+          "version": "1.0.0"
+        }
+      },
+      "name": "agentskills"
+    }
+  ],
+  "name": "pdf-processing",
+  "schema_version": "1.0.0",
+  "skills": [],
+  "version": "1.0.0"
+}

--- a/tests/fixtures/translation_agentskills_record.json
+++ b/tests/fixtures/translation_agentskills_record.json
@@ -17,11 +17,10 @@
           "description": "Extract PDF text and merge files. Use when handling PDFs.",
           "frontmatter_metadata": {
             "author": "example-org",
-            "version": "1.0.0"
+            "version": "1.0"
           },
           "license": "Apache-2.0",
-          "name": "pdf-processing",
-          "version": "1.0.0"
+          "name": "pdf-processing"
         }
       },
       "name": "agentskills"
@@ -30,5 +29,5 @@
   "name": "pdf-processing",
   "schema_version": "1.0.0",
   "skills": [],
-  "version": "1.0.0"
+  "version": "1.0"
 }

--- a/tests/fixtures/translation_agentskills_record.json
+++ b/tests/fixtures/translation_agentskills_record.json
@@ -1,0 +1,34 @@
+{
+  "authors": [],
+  "created_at": "2025-01-01T00:00:00Z",
+  "description": "Extract PDF text and merge files. Use when handling PDFs.",
+  "domains": [],
+  "modules": [
+    {
+      "data": {
+        "skill_body": "# PDF Processing Skill\n\nUse this skill when handling PDFs.",
+        "skill_file": "SKILL.md",
+        "skill_manifest": {
+          "allowed_tools": [
+            "Read",
+            "Bash(jq:*)"
+          ],
+          "compatibility": "Requires python3",
+          "description": "Extract PDF text and merge files. Use when handling PDFs.",
+          "frontmatter_metadata": {
+            "author": "example-org",
+            "version": "1.0.0"
+          },
+          "license": "Apache-2.0",
+          "name": "pdf-processing",
+          "version": "1.0.0"
+        }
+      },
+      "name": "agentskills"
+    }
+  ],
+  "name": "pdf-processing",
+  "schema_version": "1.0.0",
+  "skills": [],
+  "version": "1.0.0"
+}

--- a/tests/fixtures/translation_agentskills_record.json
+++ b/tests/fixtures/translation_agentskills_record.json
@@ -1,29 +1,40 @@
 {
-  "authors": [],
+  "authors": [
+    "example-org"
+  ],
   "created_at": "2025-01-01T00:00:00Z",
   "description": "Extract PDF text and merge files. Use when handling PDFs.",
   "domains": [],
   "modules": [
     {
+      "id": 10302,
+      "artifact": {
+        "data": "LS0tCm5hbWU6IHBkZi1wcm9jZXNzaW5nCmRlc2NyaXB0aW9uOiBFeHRyYWN0IFBERiB0ZXh0IGFuZCBtZXJnZSBmaWxlcy4gVXNlIHdoZW4gaGFuZGxpbmcgUERGcy4KbGljZW5zZTogQXBhY2hlLTIuMApjb21wYXRpYmlsaXR5OiBSZXF1aXJlcyBweXRob24zCmFsbG93ZWQtdG9vbHM6IFJlYWQgQmFzaChqcToqKQptZXRhZGF0YToKICBhdXRob3I6IGV4YW1wbGUtb3JnCiAgdmVyc2lvbjogIjEuMCIKLS0tCiMgUERGIFByb2Nlc3NpbmcgU2tpbGwKClVzZSB0aGlzIHNraWxsIHdoZW4gaGFuZGxpbmcgUERGcy4K",
+        "digest": "sha256:d5de35a17d15c7fca2d9793bf3c75976449d8d07a08064f2fe67477901c8de4d",
+        "media_type": "application/agent-skills+md",
+        "size": 291
+      },
       "data": {
-        "skill_body": "# PDF Processing Skill\n\nUse this skill when handling PDFs.",
         "skill_file": "SKILL.md",
         "skill_manifest": {
           "allowed_tools": [
             "Read",
             "Bash(jq:*)"
           ],
-          "compatibility": "Requires python3",
+          "compatibility": [
+            "Requires python3"
+          ],
           "description": "Extract PDF text and merge files. Use when handling PDFs.",
           "frontmatter_metadata": {
             "author": "example-org",
             "version": "1.0"
           },
           "license": "Apache-2.0",
-          "name": "pdf-processing"
+          "name": "pdf-processing",
+          "version": "1.0"
         }
       },
-      "name": "agentskills"
+      "name": "core/language_model/agentskills"
     }
   ],
   "name": "pdf-processing",

--- a/tests/fixtures/translation_skill.json
+++ b/tests/fixtures/translation_skill.json
@@ -1,0 +1,3 @@
+{
+  "skillMarkdown": "---\nname: pdf-processing\ndescription: Extract PDF text and merge files. Use when handling PDFs.\nlicense: Apache-2.0\ncompatibility: Requires python3\nversion: 1.0.0\nallowed-tools: Read Bash(jq:*)\nmetadata:\n  author: example-org\n  version: \"1.0.0\"\n---\n# PDF Processing Skill\n\nUse this skill when handling PDFs.\n"
+}

--- a/tests/fixtures/translation_skill.json
+++ b/tests/fixtures/translation_skill.json
@@ -1,3 +1,3 @@
 {
-  "skillMarkdown": "---\nname: pdf-processing\ndescription: Extract PDF text and merge files. Use when handling PDFs.\nlicense: Apache-2.0\ncompatibility: Requires python3\nversion: 1.0.0\nallowed-tools: Read Bash(jq:*)\nmetadata:\n  author: example-org\n  version: \"1.0.0\"\n---\n# PDF Processing Skill\n\nUse this skill when handling PDFs.\n"
+  "skillMarkdown": "---\nname: pdf-processing\ndescription: Extract PDF text and merge files. Use when handling PDFs.\nlicense: Apache-2.0\ncompatibility: Requires python3\nallowed-tools: Read Bash(jq:*)\nmetadata:\n  author: example-org\n  version: \"1.0\"\n---\n# PDF Processing Skill\n\nUse this skill when handling PDFs.\n"
 }

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -12,7 +12,7 @@ require (
 )
 
 require (
-	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1 // indirect
+	buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -2,8 +2,8 @@ buf.build/gen/go/agntcy/oasf-sdk/grpc/go v1.5.1-20251104080327-0fc042e98377.2 h1
 buf.build/gen/go/agntcy/oasf-sdk/grpc/go v1.5.1-20251104080327-0fc042e98377.2/go.mod h1:u3K3LJQQEfds8H3SdiG8iMLMlBbRRnJuQvYQp02cljE=
 buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260128161637-a77f334c8c86.1 h1:zAc/7WXMpvrf+5QcPfoI81shUjFaatEFEIVkflk/xvo=
 buf.build/gen/go/agntcy/oasf-sdk/protocolbuffers/go v1.36.11-20260128161637-a77f334c8c86.1/go.mod h1:EEQp9sY+88ieMjKf9W4Uf9t3X6qV1nHY0DcGOxsMlac=
-buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1 h1:c5Knf+Ki5RRjRAZIK11brQyaI2On4lOvel/cNg4hnJc=
-buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260127123814-046ed24ce65a.1/go.mod h1:y7UzNChPK2OBXQxpwimQg6fSgSFLC1jZXTk9Y7HFfNc=
+buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1 h1:zG4FFqTORpGsQVx1fo5qjcYZbNZqk56B6y0986Nexzg=
+buf.build/gen/go/agntcy/oasf/protocolbuffers/go v1.36.11-20260409142051-fd433ebe75bb.1/go.mod h1:y7UzNChPK2OBXQxpwimQg6fSgSFLC1jZXTk9Y7HFfNc=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/tests/translation_test.go
+++ b/tests/translation_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // normalizeMapOrder recursively normalizes map order by sorting keys for deterministic comparison.
@@ -637,10 +636,7 @@ func TestRecordToSkillMarkdown(t *testing.T) {
 		t.Fatalf("Failed to decode agentskills record: %v", err)
 	}
 
-	// Extract the body from the skill_body field of the module data for the WithBody option.
-	body := extractSkillBody(record)
-
-	actualMarkdown, err := translator.RecordToSkillMarkdown(record, translator.WithBody(body))
+	actualMarkdown, err := translator.RecordToSkillMarkdown(record)
 	if err != nil {
 		t.Fatalf("RecordToSkillMarkdown() error: %v", err)
 	}
@@ -651,30 +647,6 @@ func TestRecordToSkillMarkdown(t *testing.T) {
 	if actualMarkdown != expectedMarkdown {
 		t.Fatalf("Markdown mismatch.\nExpected:\n%s\nActual:\n%s", expectedMarkdown, actualMarkdown)
 	}
-}
-
-// extractSkillBody retrieves the skill_body field from the agentskills module data in a record.
-func extractSkillBody(record *structpb.Struct) string {
-	modulesVal, ok := record.GetFields()["modules"]
-	if !ok {
-		return ""
-	}
-
-	for _, modVal := range modulesVal.GetListValue().GetValues() {
-		mod := modVal.GetStructValue()
-		if mod == nil {
-			continue
-		}
-
-		if mod.GetFields()["name"].GetStringValue() == "agentskills" {
-			data := mod.GetFields()["data"].GetStructValue()
-			if data != nil {
-				return data.GetFields()["skill_body"].GetStringValue()
-			}
-		}
-	}
-
-	return ""
 }
 
 func mustMarshalIndent(v any) string {

--- a/tests/translation_test.go
+++ b/tests/translation_test.go
@@ -6,14 +6,9 @@ package tests
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"maps"
-	"os"
-	"path/filepath"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -588,184 +583,105 @@ var _ = Describe("Translation Service E2E", func() {
 	})
 })
 
-func TestSkillMarkdownRoundTrip(t *testing.T) {
-	content, err := os.ReadFile(filepath.Join("fixtures", "SKILL.md"))
+func TestSkillMarkdownToRecord(t *testing.T) {
+	encodedSkillData, err := decoder.JsonToProto(translationSkillMarkdown)
 	if err != nil {
-		t.Fatalf("Failed to read SKILL.md: %v", err)
+		t.Fatalf("Failed to encode skill markdown data: %v", err)
 	}
 
-	originalManifest, originalBody, err := parseSkillMarkdown(string(content))
+	record, err := translator.SkillMarkdownToRecord(encodedSkillData)
 	if err != nil {
-		t.Fatalf("Failed to parse SKILL.md: %v", err)
+		t.Fatalf("SkillMarkdownToRecord() error: %v", err)
 	}
 
-	recordStruct, err := structpb.NewStruct(map[string]any{
-		"schema_version": "1.0.0",
-		"modules": []any{
-			map[string]any{
-				"name": "agentskills",
-				"data": map[string]any{
-					"skill_file":     "SKILL.md",
-					"skill_manifest": manifestToStruct(originalManifest),
-				},
-			},
-		},
-	})
+	actualJSON, err := json.MarshalIndent(record.AsMap(), "", "  ")
 	if err != nil {
-		t.Fatalf("Failed to build record struct: %v", err)
+		t.Fatalf("Failed to marshal record to JSON: %v", err)
 	}
 
-	rebuiltMarkdown, err := translator.BuildSkillMarkdownFromRecord(recordStruct, translator.WithBody(originalBody))
-	if err != nil {
-		t.Fatalf("BuildSkillMarkdownFromRecord() error: %v", err)
+	var expectedOutput map[string]any
+
+	if err := json.Unmarshal(expectedSkillToRecordOutput, &expectedOutput); err != nil {
+		t.Fatalf("Failed to unmarshal expected output: %v", err)
 	}
 
-	rebuiltManifest, rebuiltBody, err := parseSkillMarkdown(rebuiltMarkdown)
-	if err != nil {
-		t.Fatalf("Failed to parse rebuilt SKILL.md: %v", err)
+	var actualOutput map[string]any
+
+	if err := json.Unmarshal(actualJSON, &actualOutput); err != nil {
+		t.Fatalf("Failed to unmarshal actual output: %v", err)
 	}
 
-	if !reflect.DeepEqual(normalizeManifest(originalManifest), normalizeManifest(rebuiltManifest)) {
-		original := normalizeManifest(originalManifest)
-		rebuilt := normalizeManifest(rebuiltManifest)
-		t.Fatalf("Manifest mismatch after roundtrip\noriginal: %#v\nrebuilt: %#v", original, rebuilt)
+	// created_at is dynamically generated; verify it exists and is valid RFC3339, then exclude from comparison.
+	actualCreatedAt, ok := actualOutput["created_at"].(string)
+	if !ok || actualCreatedAt == "" {
+		t.Fatalf("created_at should be present and non-empty")
 	}
 
-	if strings.TrimSpace(originalBody) != strings.TrimSpace(rebuiltBody) {
-		t.Fatalf("Body mismatch after roundtrip")
+	if _, err := time.Parse(time.RFC3339, actualCreatedAt); err != nil {
+		t.Fatalf("created_at should be valid RFC3339 timestamp: %v", err)
+	}
+
+	delete(actualOutput, "created_at")
+	delete(expectedOutput, "created_at")
+	delete(expectedOutput, "_comment_created_at")
+
+	if !reflect.DeepEqual(actualOutput, expectedOutput) {
+		t.Fatalf("Record mismatch.\nExpected:\n%s\nActual:\n%s",
+			mustMarshalIndent(expectedOutput), mustMarshalIndent(actualOutput))
 	}
 }
 
-type skillManifest struct {
-	Name          string
-	Description   string
-	License       string
-	Compatibility string
-	Version       string
-	AllowedTools  []string
-	Metadata      map[string]string
-}
-
-func parseSkillMarkdown(content string) (skillManifest, string, error) {
-	sections := strings.Split(content, "---")
-	if len(sections) < 3 {
-		return skillManifest{}, "", ErrInvalidFrontmatter
+func TestRecordToSkillMarkdown(t *testing.T) {
+	record, err := decoder.JsonToProto(translationAgentSkillsRecord)
+	if err != nil {
+		t.Fatalf("Failed to decode agentskills record: %v", err)
 	}
 
-	frontmatter := strings.TrimSpace(sections[1])
-	body := strings.TrimSpace(strings.Join(sections[2:], "---"))
+	// Extract the body from the skill_body field of the module data for the WithBody option.
+	body := extractSkillBody(record)
 
-	manifest := skillManifest{Metadata: map[string]string{}}
+	actualMarkdown, err := translator.RecordToSkillMarkdown(record, translator.WithBody(body))
+	if err != nil {
+		t.Fatalf("RecordToSkillMarkdown() error: %v", err)
+	}
 
-	lines := strings.Split(frontmatter, "\n")
-	for i := 0; i < len(lines); i++ {
-		line := strings.TrimSpace(lines[i])
-		if line != "" {
-			if line == "metadata:" {
-				for i+1 < len(lines) {
-					next := lines[i+1]
-					if !strings.HasPrefix(next, "  ") {
-						break
-					}
+	expectedMarkdown := strings.TrimSpace(string(expectedRecordToSkillOutput))
+	actualMarkdown = strings.TrimSpace(actualMarkdown)
 
-					i++
-					key, value := splitKeyValue(strings.TrimSpace(next))
-					manifest.Metadata[key] = value
-				}
-			} else {
-				key, value := splitKeyValue(line)
-				switch key {
-				case "name":
-					manifest.Name = value
-				case "description":
-					manifest.Description = value
-				case "license":
-					manifest.License = value
-				case "compatibility":
-					manifest.Compatibility = value
-				case "version":
-					manifest.Version = value
-				case "allowed-tools":
-					manifest.AllowedTools = strings.Fields(value)
-				}
+	if actualMarkdown != expectedMarkdown {
+		t.Fatalf("Markdown mismatch.\nExpected:\n%s\nActual:\n%s", expectedMarkdown, actualMarkdown)
+	}
+}
+
+// extractSkillBody retrieves the skill_body field from the agentskills module data in a record.
+func extractSkillBody(record *structpb.Struct) string {
+	modulesVal, ok := record.GetFields()["modules"]
+	if !ok {
+		return ""
+	}
+
+	for _, modVal := range modulesVal.GetListValue().GetValues() {
+		mod := modVal.GetStructValue()
+		if mod == nil {
+			continue
+		}
+
+		if mod.GetFields()["name"].GetStringValue() == "agentskills" {
+			data := mod.GetFields()["data"].GetStructValue()
+			if data != nil {
+				return data.GetFields()["skill_body"].GetStringValue()
 			}
 		}
 	}
 
-	return manifest, body, nil
+	return ""
 }
 
-var ErrInvalidFrontmatter = errors.New("invalid frontmatter")
-
-func splitKeyValue(line string) (string, string) {
-	parts := strings.SplitN(line, ":", 2)
-	key := strings.TrimSpace(parts[0])
-	value := ""
-
-	if len(parts) > 1 {
-		value = strings.TrimSpace(parts[1])
+func mustMarshalIndent(v any) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("<marshal error: %v>", err)
 	}
 
-	if strings.HasPrefix(value, "\"") {
-		if unquoted, err := strconv.Unquote(value); err == nil {
-			value = unquoted
-		}
-	}
-
-	return key, value
-}
-
-func manifestToStruct(manifest skillManifest) map[string]any {
-	data := map[string]any{
-		"name":        manifest.Name,
-		"description": manifest.Description,
-	}
-
-	if manifest.License != "" {
-		data["license"] = manifest.License
-	}
-
-	if manifest.Compatibility != "" {
-		data["compatibility"] = manifest.Compatibility
-	}
-
-	if manifest.Version != "" {
-		data["version"] = manifest.Version
-	}
-
-	if len(manifest.AllowedTools) > 0 {
-		allowed := make([]any, 0, len(manifest.AllowedTools))
-		for _, tool := range manifest.AllowedTools {
-			allowed = append(allowed, tool)
-		}
-
-		data["allowed_tools"] = allowed
-	}
-
-	if len(manifest.Metadata) > 0 {
-		metadata := map[string]any{}
-		for key, value := range manifest.Metadata {
-			metadata[key] = value
-		}
-
-		data["frontmatter_metadata"] = metadata
-	}
-
-	return data
-}
-
-func normalizeManifest(manifest skillManifest) skillManifest {
-	copyManifest := manifest
-	copyManifest.Metadata = map[string]string{}
-	maps.Copy(copyManifest.Metadata, manifest.Metadata)
-
-	if copyManifest.Version != "" {
-		if _, ok := copyManifest.Metadata["version"]; !ok {
-			copyManifest.Metadata["version"] = copyManifest.Version
-		}
-	}
-
-	sort.Strings(copyManifest.AllowedTools)
-
-	return copyManifest
+	return string(b)
 }


### PR DESCRIPTION
This PR adds `RecordToSkillMarkdown` and SkillMarkdownToRecord` translation functions that leverages the new `module.artifact` in OASF 1.0.0, also protos for multi-language support with the server.

Closes #151 