### PR TITLE
feat(translator): translate OASF records to AI Catalog entries

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -240,7 +240,7 @@ Output:
 
 ## AI Catalog
 
-Project an OASF record onto its AI Catalog entry using the `RecordToCatalog` RPC method. A single known integration module (`integration/mcp`, `integration/a2a`, `core/language_model/agentskills`) yields a leaf entry; multiple modules yield an `application/ai-catalog+json` container with one nested entry per module. A `cid` is required; `host` (defaults to `agntcy.org`) and `specVersion` (defaults to `1.0`) are optional.
+Project an OASF record onto its AI Catalog entry using the `RecordToCatalog` RPC method. A single known integration module (`integration/mcp`, `integration/a2a`, `core/language_model/agentskills`) yields a leaf entry; multiple modules yield an `application/ai-catalog+json` container with one nested entry per module. A `cid` is required; `host` (defaults to `org.agntcy`) and `specVersion` (defaults to `1.0`) are optional.
 
 **Note:** Available once the proto bindings are generated and the server handler is wired (follow-up to this PR).
 
@@ -253,7 +253,7 @@ Output:
 ```json
 {
   "data": {
-    "identifier": "urn:ai:agntcy.org:cid:baeareibxiiy45pg4bjwhbijgh35epzjhnh6lvaxts2qggcgssn3glzdh64",
+    "identifier": "urn:ai:org.agntcy:cid:baeareibxiiy45pg4bjwhbijgh35epzjhnh6lvaxts2qggcgssn3glzdh64",
     "media_type": "application/a2a-agent-card+json",
     "display_name": "example-agent",
     "data": {}

--- a/USAGE.md
+++ b/USAGE.md
@@ -238,6 +238,29 @@ Output:
 }
 ```
 
+## AI Catalog
+
+Project an OASF record onto its AI Catalog entry using the `RecordToCatalog` RPC method. A single known integration module (`integration/mcp`, `integration/a2a`, `core/language_model/agentskills`) yields a leaf entry; multiple modules yield an `application/ai-catalog+json` container with one nested entry per module. A `cid` is required; `host` (defaults to `agntcy.org`) and `specVersion` (defaults to `1.0`) are optional.
+
+**Note:** Available once the proto bindings are generated and the server handler is wired (follow-up to this PR).
+
+```bash
+cat tests/fixtures/translation_0.8.0_record.json | jq '{record: ., cid: "baeareibxiiy45pg4bjwhbijgh35epzjhnh6lvaxts2qggcgssn3glzdh64"}' | grpcurl -plaintext -d @ localhost:31234 agntcy.oasfsdk.translation.v1.TranslationService/RecordToCatalog
+```
+
+Output:
+
+```json
+{
+  "data": {
+    "identifier": "urn:ai:agntcy.org:cid:baeareibxiiy45pg4bjwhbijgh35epzjhnh6lvaxts2qggcgssn3glzdh64",
+    "media_type": "application/a2a-agent-card+json",
+    "display_name": "example-agent",
+    "data": {}
+  }
+}
+```
+
 # Schema Service
 
 The OASF SDK Schema Service provides access to OASF schema definitions, allowing you to fetch schema content and extract specific sections like skills, domains, and modules from the schema.

--- a/e2e/translation_test.go
+++ b/e2e/translation_test.go
@@ -636,4 +636,12 @@ var _ = Describe("Translation Service E2E", func() {
 			Expect(actualMarkdown).To(Equal(expectedMarkdown), "SKILL.md should match expected output")
 		})
 	})
+
+	// TODO(catalog-grpc): add an "AI Catalog Projection" Context here once the
+	// RecordToCatalog bindings are generated and e2e/go.mod is bumped. It
+	// should call client.RecordToCatalog with a request carrying a record plus
+	// a cid (and optionally host / spec version), then assert the projected
+	// entry against a new expected_catalog_output.json fixture. Both that
+	// fixture and a translation_catalog_record.json input must be added to
+	// e2e/fixtures and embedded in embed_test.go.
 })

--- a/pkg/translator/catalog.go
+++ b/pkg/translator/catalog.go
@@ -1,0 +1,423 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package translator
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// AI Catalog media types advertised by records carrying a given OASF
+// integration module.
+const (
+	A2ACatalogMediaType         = "application/a2a-agent-card+json"
+	MCPCatalogMediaType         = "application/mcp-server+json"
+	AgentSkillsCatalogMediaType = "application/ai-skill+md"
+
+	// CatalogContainerMediaType is the media type used for a container
+	// entry: a record that bundles more than one known module.
+	CatalogContainerMediaType = "application/ai-catalog+json"
+
+	// DefaultCatalogURNHost is the authority segment used in entry URNs
+	// ("urn:ai:<host>:cid:<cid>[:<suffix>]") when no host is supplied via
+	// WithCatalogHost.
+	DefaultCatalogURNHost = "agntcy.org"
+
+	// DefaultCatalogSpecVersion is the AI Catalog spec version embedded in
+	// the nested catalog produced for multi-module records.
+	DefaultCatalogSpecVersion = "1.0"
+)
+
+// catalogModuleProjection captures the per-module projection rules: the
+// media type a module advertises, the URN suffix used to disambiguate the
+// module's entry inside a multi-module container, and a short human label
+// used to synthesise nested display names.
+type catalogModuleProjection struct {
+	MediaType string
+	URNSuffix string
+	Label     string
+}
+
+// catalogModules maps OASF integration module names onto their AI Catalog
+// projection rules. A record is projectable only if it carries at least
+// one of these modules.
+var catalogModules = map[string]catalogModuleProjection{
+	MCPModuleName:         {MediaType: MCPCatalogMediaType, URNSuffix: "mcp", Label: "MCP"},
+	A2AModuleName:         {MediaType: A2ACatalogMediaType, URNSuffix: "a2a", Label: "A2A"},
+	AgentSkillsModuleName: {MediaType: AgentSkillsCatalogMediaType, URNSuffix: "agentskill", Label: "Skill"},
+}
+
+// CatalogOption configures RecordToCatalog.
+type CatalogOption func(*catalogOptions)
+
+type catalogOptions struct {
+	host        string
+	cid         string
+	specVersion string
+}
+
+// WithCatalogHost sets the authority segment of the entry URN. Defaults to
+// DefaultCatalogURNHost.
+func WithCatalogHost(host string) CatalogOption {
+	return func(o *catalogOptions) {
+		if h := strings.TrimSpace(host); h != "" {
+			o.host = h
+		}
+	}
+}
+
+// WithCatalogCID sets the content identifier used in the entry URN. The
+// raw OASF record does not carry its own CID, so callers MUST supply one;
+// RecordToCatalog returns an error when no CID is provided.
+func WithCatalogCID(cid string) CatalogOption {
+	return func(o *catalogOptions) {
+		o.cid = cid
+	}
+}
+
+// WithCatalogSpecVersion overrides the AI Catalog spec version embedded in
+// the nested catalog of a multi-module container.
+func WithCatalogSpecVersion(version string) CatalogOption {
+	return func(o *catalogOptions) {
+		if v := strings.TrimSpace(version); v != "" {
+			o.specVersion = v
+		}
+	}
+}
+
+// catalogModule is a known module extracted from a record: its name and
+// the structured `data` object carried alongside it.
+type catalogModule struct {
+	name string
+	data *structpb.Struct
+}
+
+// RecordToCatalog projects an OASF record onto its AI Catalog entry
+// representation, returned as a structpb.Struct. The result depends
+// on how many known integration modules the record carries.
+//
+//   - 0 known modules → error; a catalog entry MUST point at an artifact
+//     and there is nothing to project.
+//   - 1 known module  → a LEAF entry whose media_type matches the module
+//     (e.g. "application/a2a-agent-card+json") and whose `data` is the
+//     module's structured data.
+//   - 2+ known modules → a CONTAINER entry with media_type
+//     "application/ai-catalog+json" whose `data` embeds a nested AI Catalog
+//     with one entry per known module.
+//
+// The projection is deliberately pure: trust/identity metadata (e.g.
+// signature-derived TrustManifests) and any publisher/host data beyond the
+// URN host are layered on by the caller and intentionally not produced
+// here.
+func RecordToCatalog(record *structpb.Struct, opts ...CatalogOption) (*structpb.Struct, error) {
+	if record == nil {
+		return nil, errors.New("record is nil")
+	}
+
+	options := &catalogOptions{
+		host:        DefaultCatalogURNHost,
+		specVersion: DefaultCatalogSpecVersion,
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	cid := strings.TrimSpace(options.cid)
+	if cid == "" {
+		return nil, errors.New("catalog CID is required (set WithCatalogCID)")
+	}
+
+	modules := knownCatalogModules(record)
+	if len(modules) == 0 {
+		return nil, errors.New("record has no known catalog modules")
+	}
+
+	name := recordStringField(record, "name")
+	version := recordStringField(record, "version")
+	description := strings.TrimSpace(recordStringField(record, "description"))
+	updatedAt := recordStringField(record, "created_at")
+	tags := catalogTags(record)
+
+	baseURN := catalogURN(options.host, cid, "")
+
+	// Single known module — leaf entry on the parent URN.
+	if len(modules) == 1 {
+		entry := moduleToCatalogEntry(modules[0], baseURN)
+		entry.Fields["display_name"] = catalogStringValue(firstNonEmptyString(name, baseURN))
+		setCatalogTags(entry, tags)
+		setOptionalString(entry, "version", version)
+		setOptionalString(entry, "description", description)
+		setOptionalString(entry, "updated_at", updatedAt)
+
+		return entry, nil
+	}
+
+	// 2+ known modules — container whose data is a nested AI Catalog.
+	nested := make([]*structpb.Value, 0, len(modules))
+
+	for _, m := range modules {
+		moduleURN := catalogURN(options.host, cid, catalogModules[m.name].URNSuffix)
+
+		entry := moduleToCatalogEntry(m, moduleURN)
+		entry.Fields["display_name"] = catalogStringValue(moduleDisplayName(m, name))
+
+		nested = append(nested, structpb.NewStructValue(entry))
+	}
+
+	nestedCatalog := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"spec_version": catalogStringValue(options.specVersion),
+			"entries": {
+				Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: nested}},
+			},
+		},
+	}
+
+	container := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"identifier":   catalogStringValue(baseURN),
+			"display_name": catalogStringValue(firstNonEmptyString(name, baseURN)),
+			"media_type":   catalogStringValue(CatalogContainerMediaType),
+			"data":         structpb.NewStructValue(nestedCatalog),
+		},
+	}
+	setCatalogTags(container, tags)
+	setOptionalString(container, "version", version)
+	setOptionalString(container, "description", description)
+	setOptionalString(container, "updated_at", updatedAt)
+
+	return container, nil
+}
+
+// moduleToCatalogEntry builds a leaf catalog entry for a single module.
+//
+// A catalog entry requires exactly one of `url` or `data`. We always carry
+// the module's structured data inline via `data` in OASF.
+func moduleToCatalogEntry(m catalogModule, identifier string) *structpb.Struct {
+	proj := catalogModules[m.name]
+
+	data := m.data
+	if data == nil {
+		data = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+
+	return &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"identifier": catalogStringValue(identifier),
+			"media_type": catalogStringValue(proj.MediaType),
+			"data":       structpb.NewStructValue(data),
+		},
+	}
+}
+
+// knownCatalogModules returns the record's modules that have a catalog
+// projection rule, sorted by name for deterministic output.
+func knownCatalogModules(record *structpb.Struct) []catalogModule {
+	modulesVal, ok := record.GetFields()["modules"]
+	if !ok {
+		return nil
+	}
+
+	list := modulesVal.GetListValue()
+	if list == nil {
+		return nil
+	}
+
+	out := make([]catalogModule, 0, len(list.GetValues()))
+
+	for _, v := range list.GetValues() {
+		moduleStruct := v.GetStructValue()
+		if moduleStruct == nil {
+			continue
+		}
+
+		nameField := moduleStruct.GetFields()["name"]
+		if nameField == nil {
+			continue
+		}
+
+		name := nameField.GetStringValue()
+		if _, known := catalogModules[name]; !known {
+			continue
+		}
+
+		out = append(out, catalogModule{
+			name: name,
+			data: moduleStruct.GetFields()["data"].GetStructValue(),
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].name < out[j].name })
+
+	return out
+}
+
+// catalogTags assembles the OASF-taxonomy + annotation tag list shared by
+// leaf and container entries: one tag per skill and domain
+// ("oasf:v<schema>:skills:<name>" / "oasf:v<schema>:domain:<name>"),
+// followed by record annotations ("key" or "key=value").
+func catalogTags(record *structpb.Struct) []string {
+	schemaVer := strings.TrimPrefix(recordStringField(record, "schema_version"), "v")
+	if schemaVer == "" {
+		schemaVer = "1"
+	}
+
+	skills := taxonomyNames(record, "skills")
+	domains := taxonomyNames(record, "domains")
+	annotations := sortedAnnotations(record)
+
+	out := make([]string, 0, len(skills)+len(domains)+len(annotations))
+
+	for _, s := range skills {
+		out = append(out, fmt.Sprintf("oasf:v%s:skills:%s", schemaVer, s))
+	}
+
+	for _, d := range domains {
+		out = append(out, fmt.Sprintf("oasf:v%s:domain:%s", schemaVer, d))
+	}
+
+	out = append(out, annotations...)
+
+	return out
+}
+
+// taxonomyNames extracts the "name" of each entry in a record's skills or
+// domains list, preserving record order.
+func taxonomyNames(record *structpb.Struct, field string) []string {
+	val, ok := record.GetFields()[field]
+	if !ok {
+		return nil
+	}
+
+	list := val.GetListValue()
+	if list == nil {
+		return nil
+	}
+
+	out := make([]string, 0, len(list.GetValues()))
+
+	for _, v := range list.GetValues() {
+		entry := v.GetStructValue()
+		if entry == nil {
+			continue
+		}
+
+		if name := entry.GetFields()["name"].GetStringValue(); name != "" {
+			out = append(out, name)
+		}
+	}
+
+	return out
+}
+
+// sortedAnnotations renders a record's annotations map into a
+// deterministic (key-sorted) list of "key" or "key=value" tags.
+func sortedAnnotations(record *structpb.Struct) []string {
+	val, ok := record.GetFields()["annotations"]
+	if !ok {
+		return nil
+	}
+
+	annotations := val.GetStructValue()
+	if annotations == nil || len(annotations.GetFields()) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(annotations.GetFields()))
+	for key := range annotations.GetFields() {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	out := make([]string, 0, len(keys))
+
+	for _, key := range keys {
+		value := annotations.GetFields()[key].GetStringValue()
+		if value == "" {
+			out = append(out, key)
+		} else {
+			out = append(out, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+
+	return out
+}
+
+// moduleDisplayName synthesises the nested entry display name as
+// "<record name> (<label>)", falling back gracefully when either piece is
+// missing.
+func moduleDisplayName(m catalogModule, recordName string) string {
+	label := catalogModules[m.name].Label
+
+	switch {
+	case recordName != "" && label != "":
+		return fmt.Sprintf("%s (%s)", recordName, label)
+	case recordName != "":
+		return recordName
+	case label != "":
+		return label
+	default:
+		return m.name
+	}
+}
+
+// catalogURN builds "urn:ai:<host>:cid:<cid>" with an optional ":<suffix>"
+// used to disambiguate nested entries inside a container.
+func catalogURN(host, cid, suffix string) string {
+	base := fmt.Sprintf("urn:ai:%s:cid:%s", host, cid)
+	if suffix == "" {
+		return base
+	}
+
+	return base + ":" + suffix
+}
+
+// recordStringField returns a top-level string field of the record, or "".
+func recordStringField(record *structpb.Struct, field string) string {
+	return record.GetFields()[field].GetStringValue()
+}
+
+// catalogStringValue wraps a string in a structpb.Value.
+func catalogStringValue(s string) *structpb.Value {
+	return &structpb.Value{Kind: &structpb.Value_StringValue{StringValue: s}}
+}
+
+// setOptionalString sets a string field on an entry only when non-empty.
+func setOptionalString(entry *structpb.Struct, field, value string) {
+	if value != "" {
+		entry.Fields[field] = catalogStringValue(value)
+	}
+}
+
+// setCatalogTags sets the "tags" field on an entry only when non-empty.
+func setCatalogTags(entry *structpb.Struct, tags []string) {
+	if len(tags) == 0 {
+		return
+	}
+
+	values := make([]*structpb.Value, 0, len(tags))
+	for _, t := range tags {
+		values = append(values, catalogStringValue(t))
+	}
+
+	entry.Fields["tags"] = &structpb.Value{
+		Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: values}},
+	}
+}
+
+// firstNonEmptyString returns the first non-empty string, or "".
+func firstNonEmptyString(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+
+	return ""
+}

--- a/pkg/translator/catalog.go
+++ b/pkg/translator/catalog.go
@@ -26,7 +26,7 @@ const (
 	// DefaultCatalogURNHost is the authority segment used in entry URNs
 	// ("urn:ai:<host>:cid:<cid>[:<suffix>]") when no host is supplied via
 	// WithCatalogHost.
-	DefaultCatalogURNHost = "agntcy.org"
+	DefaultCatalogURNHost = "org.agntcy"
 
 	// DefaultCatalogSpecVersion is the AI Catalog spec version embedded in
 	// the nested catalog produced for multi-module records.

--- a/pkg/translator/catalog_test.go
+++ b/pkg/translator/catalog_test.go
@@ -1,0 +1,344 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package translator_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/agntcy/oasf-sdk/pkg/translator"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// moduleMap builds a minimal OASF module object: name + structured data.
+func moduleMap(name string, data map[string]any) map[string]any {
+	m := map[string]any{"name": name}
+	if data != nil {
+		m["data"] = data
+	}
+
+	return m
+}
+
+// taxonomyMap builds a {"name": ...} taxonomy entry (skill/domain).
+func taxonomyMap(name string) map[string]any {
+	return map[string]any{"name": name}
+}
+
+func mustStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+
+	s, err := structpb.NewStruct(m)
+	if err != nil {
+		t.Fatalf("failed to build struct: %v", err)
+	}
+
+	return s
+}
+
+func entryString(t *testing.T, entry *structpb.Struct, field string) string {
+	t.Helper()
+
+	return entry.GetFields()[field].GetStringValue()
+}
+
+func entryTags(entry *structpb.Struct) []string {
+	list := entry.GetFields()["tags"].GetListValue()
+	if list == nil {
+		return nil
+	}
+
+	out := make([]string, 0, len(list.GetValues()))
+	for _, v := range list.GetValues() {
+		out = append(out, v.GetStringValue())
+	}
+
+	return out
+}
+
+const testCID = "baeareibxiiy45pg4bjwhbijgh35epzjhnh6lvaxts2qggcgssn3glzdh64"
+
+func TestRecordToCatalog_MCPLeaf(t *testing.T) {
+	moduleData := map[string]any{
+		"name": "io.github.github/github-mcp-server",
+		"connections": []any{
+			map[string]any{"type": "stdio", "command": "docker"},
+		},
+	}
+
+	record := mustStruct(t, map[string]any{
+		"name":           "io.github.github/github-mcp-server",
+		"version":        "1.0.4",
+		"description":    "Connect AI assistants to GitHub.",
+		"schema_version": "1.0.0",
+		"created_at":     "2026-05-12T00:40:01Z",
+		"skills": []any{
+			taxonomyMap("retrieval_augmented_generation/document_or_database_question_answering"),
+			taxonomyMap("retrieval_augmented_generation/retrieval_of_information"),
+		},
+		"domains": []any{taxonomyMap("technology/cloud_computing")},
+		"modules": []any{moduleMap(translator.MCPModuleName, moduleData)},
+	})
+
+	entry, err := translator.RecordToCatalog(record, translator.WithCatalogCID(testCID))
+	if err != nil {
+		t.Fatalf("RecordToCatalog() error: %v", err)
+	}
+
+	if got, want := entryString(t, entry, "identifier"), "urn:ai:agntcy.org:cid:"+testCID; got != want {
+		t.Errorf("identifier = %q, want %q", got, want)
+	}
+
+	if got := entryString(t, entry, "media_type"); got != translator.MCPCatalogMediaType {
+		t.Errorf("media_type = %q, want %q", got, translator.MCPCatalogMediaType)
+	}
+
+	if got := entryString(t, entry, "display_name"); got != "io.github.github/github-mcp-server" {
+		t.Errorf("display_name = %q", got)
+	}
+
+	if got := entryString(t, entry, "version"); got != "1.0.4" {
+		t.Errorf("version = %q, want 1.0.4", got)
+	}
+
+	if got := entryString(t, entry, "updated_at"); got != "2026-05-12T00:40:01Z" {
+		t.Errorf("updated_at = %q", got)
+	}
+
+	// data must equal the module's structured data, not the artifact descriptor.
+	data := entry.GetFields()["data"].GetStructValue()
+	if data == nil {
+		t.Fatal("expected inline data on leaf entry")
+	}
+
+	if got := data.GetFields()["name"].GetStringValue(); got != "io.github.github/github-mcp-server" {
+		t.Errorf("data.name = %q", got)
+	}
+
+	wantTags := []string{
+		"oasf:v1.0.0:skills:retrieval_augmented_generation/document_or_database_question_answering",
+		"oasf:v1.0.0:skills:retrieval_augmented_generation/retrieval_of_information",
+		"oasf:v1.0.0:domain:technology/cloud_computing",
+	}
+	if got := entryTags(entry); !slices.Equal(got, wantTags) {
+		t.Errorf("tags = %v, want %v", got, wantTags)
+	}
+}
+
+func TestRecordToCatalog_A2ALeaf(t *testing.T) {
+	record := mustStruct(t, map[string]any{
+		"name":           "Langraph Planner Agent",
+		"version":        "1.0.0",
+		"schema_version": "1.0.0",
+		"modules": []any{
+			moduleMap(translator.A2AModuleName, map[string]any{
+				"card_schema_version": "v1.0.0",
+				"card_data":           map[string]any{"name": "Langraph Planner Agent"},
+			}),
+		},
+	})
+
+	entry, err := translator.RecordToCatalog(record, translator.WithCatalogCID(testCID))
+	if err != nil {
+		t.Fatalf("RecordToCatalog() error: %v", err)
+	}
+
+	if got := entryString(t, entry, "media_type"); got != translator.A2ACatalogMediaType {
+		t.Errorf("media_type = %q, want %q", got, translator.A2ACatalogMediaType)
+	}
+
+	if got, want := entryString(t, entry, "identifier"), "urn:ai:agntcy.org:cid:"+testCID; got != want {
+		t.Errorf("identifier = %q, want %q", got, want)
+	}
+}
+
+func TestRecordToCatalog_SkillLeaf(t *testing.T) {
+	record := mustStruct(t, map[string]any{
+		"name":           "brand-guidelines",
+		"version":        "1.0.0",
+		"schema_version": "1.0.0",
+		"domains": []any{
+			taxonomyMap("technology/internet_of_things"),
+			taxonomyMap("technology/software_engineering"),
+		},
+		"modules": []any{
+			moduleMap(translator.AgentSkillsModuleName, map[string]any{
+				"skill_file": "SKILL.md",
+			}),
+		},
+	})
+
+	entry, err := translator.RecordToCatalog(record, translator.WithCatalogCID(testCID))
+	if err != nil {
+		t.Fatalf("RecordToCatalog() error: %v", err)
+	}
+
+	if got := entryString(t, entry, "media_type"); got != translator.AgentSkillsCatalogMediaType {
+		t.Errorf("media_type = %q, want %q", got, translator.AgentSkillsCatalogMediaType)
+	}
+
+	wantTags := []string{
+		"oasf:v1.0.0:domain:technology/internet_of_things",
+		"oasf:v1.0.0:domain:technology/software_engineering",
+	}
+	if got := entryTags(entry); !slices.Equal(got, wantTags) {
+		t.Errorf("tags = %v, want %v", got, wantTags)
+	}
+}
+
+func TestRecordToCatalog_MultiModuleContainer(t *testing.T) {
+	record := mustStruct(t, map[string]any{
+		"name":           "multi-agent",
+		"version":        "2.0.0",
+		"schema_version": "1.0.0",
+		"skills":         []any{taxonomyMap("nlp/generation")},
+		"modules": []any{
+			moduleMap(translator.MCPModuleName, map[string]any{"name": "mcp-part"}),
+			moduleMap(translator.A2AModuleName, map[string]any{"card_data": map[string]any{}}),
+		},
+	})
+
+	entry, err := translator.RecordToCatalog(record, translator.WithCatalogCID(testCID))
+	if err != nil {
+		t.Fatalf("RecordToCatalog() error: %v", err)
+	}
+
+	if got := entryString(t, entry, "media_type"); got != translator.CatalogContainerMediaType {
+		t.Errorf("media_type = %q, want %q", got, translator.CatalogContainerMediaType)
+	}
+
+	if got, want := entryString(t, entry, "identifier"), "urn:ai:agntcy.org:cid:"+testCID; got != want {
+		t.Errorf("identifier = %q, want %q", got, want)
+	}
+
+	// Container carries the record-level tags.
+	if got := entryTags(entry); !slices.Equal(got, []string{"oasf:v1.0.0:skills:nlp/generation"}) {
+		t.Errorf("container tags = %v", got)
+	}
+
+	nestedCatalog := entry.GetFields()["data"].GetStructValue()
+	if nestedCatalog == nil {
+		t.Fatal("expected nested catalog data")
+	}
+
+	if got := nestedCatalog.GetFields()["spec_version"].GetStringValue(); got != translator.DefaultCatalogSpecVersion {
+		t.Errorf("spec_version = %q, want %q", got, translator.DefaultCatalogSpecVersion)
+	}
+
+	entries := nestedCatalog.GetFields()["entries"].GetListValue()
+	if entries == nil || len(entries.GetValues()) != 2 {
+		t.Fatalf("expected 2 nested entries, got %v", entries)
+	}
+
+	// Modules are sorted by name: "integration/a2a" < "integration/mcp".
+	first := entries.GetValues()[0].GetStructValue()
+	if got, want := first.GetFields()["identifier"].GetStringValue(), "urn:ai:agntcy.org:cid:"+testCID+":a2a"; got != want {
+		t.Errorf("first nested identifier = %q, want %q", got, want)
+	}
+
+	if got := first.GetFields()["display_name"].GetStringValue(); got != "multi-agent (A2A)" {
+		t.Errorf("first nested display_name = %q, want %q", got, "multi-agent (A2A)")
+	}
+
+	if got := first.GetFields()["media_type"].GetStringValue(); got != translator.A2ACatalogMediaType {
+		t.Errorf("first nested media_type = %q", got)
+	}
+
+	// Nested entries deliberately carry no tags.
+	if _, ok := first.GetFields()["tags"]; ok {
+		t.Error("nested entry should not carry tags")
+	}
+
+	second := entries.GetValues()[1].GetStructValue()
+	if got, want := second.GetFields()["identifier"].GetStringValue(), "urn:ai:agntcy.org:cid:"+testCID+":mcp"; got != want {
+		t.Errorf("second nested identifier = %q, want %q", got, want)
+	}
+}
+
+func TestRecordToCatalog_NoKnownModules(t *testing.T) {
+	record := mustStruct(t, map[string]any{
+		"name":    "no-modules",
+		"modules": []any{moduleMap("runtime/framework", map[string]any{"x": "y"})},
+	})
+
+	if _, err := translator.RecordToCatalog(record, translator.WithCatalogCID(testCID)); err == nil {
+		t.Error("expected error for record without known catalog modules")
+	}
+}
+
+func TestRecordToCatalog_MissingCID(t *testing.T) {
+	record := mustStruct(t, map[string]any{
+		"name":    "needs-cid",
+		"modules": []any{moduleMap(translator.MCPModuleName, map[string]any{"x": "y"})},
+	})
+
+	// No CID, and a whitespace-only CID, must both error.
+	if _, err := translator.RecordToCatalog(record); err == nil {
+		t.Error("expected error when no CID is provided")
+	}
+
+	if _, err := translator.RecordToCatalog(record, translator.WithCatalogCID("  ")); err == nil {
+		t.Error("expected error when a blank CID is provided")
+	}
+}
+
+func TestRecordToCatalog_NilRecord(t *testing.T) {
+	if _, err := translator.RecordToCatalog(nil); err == nil {
+		t.Error("expected error for nil record")
+	}
+}
+
+func TestRecordToCatalog_HostOverrideAndModuleWithoutData(t *testing.T) {
+	record := mustStruct(t, map[string]any{
+		"name":           "no-data-agent",
+		"schema_version": "1.0.0",
+		"modules":        []any{moduleMap(translator.MCPModuleName, nil)},
+	})
+
+	entry, err := translator.RecordToCatalog(record,
+		translator.WithCatalogHost("example.com"),
+		translator.WithCatalogCID("cid123"),
+	)
+	if err != nil {
+		t.Fatalf("RecordToCatalog() error: %v", err)
+	}
+
+	wantURN := "urn:ai:example.com:cid:cid123"
+	if got := entryString(t, entry, "identifier"); got != wantURN {
+		t.Errorf("identifier = %q, want %q", got, wantURN)
+	}
+
+	// The artifact is always carried as inline data (empty when the module
+	// has none); url is never set.
+	if _, ok := entry.GetFields()["data"]; !ok {
+		t.Error("expected inline data to always be present")
+	}
+
+	if _, ok := entry.GetFields()["url"]; ok {
+		t.Error("expected url never to be set")
+	}
+}
+
+func TestRecordToCatalog_AnnotationsAsTags(t *testing.T) {
+	record := mustStruct(t, map[string]any{
+		"name":           "annotated",
+		"schema_version": "1.0.0",
+		"annotations": map[string]any{
+			"team":     "platform",
+			"featured": "",
+		},
+		"modules": []any{moduleMap(translator.MCPModuleName, map[string]any{"x": "y"})},
+	})
+
+	entry, err := translator.RecordToCatalog(record, translator.WithCatalogCID(testCID))
+	if err != nil {
+		t.Fatalf("RecordToCatalog() error: %v", err)
+	}
+
+	// Annotation tags are key-sorted: "featured" (bare) before "team=platform".
+	wantTags := []string{"featured", "team=platform"}
+	if got := entryTags(entry); !slices.Equal(got, wantTags) {
+		t.Errorf("tags = %v, want %v", got, wantTags)
+	}
+}

--- a/pkg/translator/catalog_test.go
+++ b/pkg/translator/catalog_test.go
@@ -57,7 +57,10 @@ func entryTags(entry *structpb.Struct) []string {
 	return out
 }
 
-const testCID = "baeareibxiiy45pg4bjwhbijgh35epzjhnh6lvaxts2qggcgssn3glzdh64"
+const (
+	testCID     = "baeareibxiiy45pg4bjwhbijgh35epzjhnh6lvaxts2qggcgssn3glzdh64"
+	testBaseURN = "urn:ai:org.agntcy:cid:" + testCID
+)
 
 func TestRecordToCatalog_MCPLeaf(t *testing.T) {
 	moduleData := map[string]any{
@@ -86,7 +89,7 @@ func TestRecordToCatalog_MCPLeaf(t *testing.T) {
 		t.Fatalf("RecordToCatalog() error: %v", err)
 	}
 
-	if got, want := entryString(t, entry, "identifier"), "urn:ai:agntcy.org:cid:"+testCID; got != want {
+	if got, want := entryString(t, entry, "identifier"), testBaseURN; got != want {
 		t.Errorf("identifier = %q, want %q", got, want)
 	}
 
@@ -148,7 +151,7 @@ func TestRecordToCatalog_A2ALeaf(t *testing.T) {
 		t.Errorf("media_type = %q, want %q", got, translator.A2ACatalogMediaType)
 	}
 
-	if got, want := entryString(t, entry, "identifier"), "urn:ai:agntcy.org:cid:"+testCID; got != want {
+	if got, want := entryString(t, entry, "identifier"), testBaseURN; got != want {
 		t.Errorf("identifier = %q, want %q", got, want)
 	}
 }
@@ -208,7 +211,7 @@ func TestRecordToCatalog_MultiModuleContainer(t *testing.T) {
 		t.Errorf("media_type = %q, want %q", got, translator.CatalogContainerMediaType)
 	}
 
-	if got, want := entryString(t, entry, "identifier"), "urn:ai:agntcy.org:cid:"+testCID; got != want {
+	if got, want := entryString(t, entry, "identifier"), testBaseURN; got != want {
 		t.Errorf("identifier = %q, want %q", got, want)
 	}
 
@@ -233,7 +236,7 @@ func TestRecordToCatalog_MultiModuleContainer(t *testing.T) {
 
 	// Modules are sorted by name: "integration/a2a" < "integration/mcp".
 	first := entries.GetValues()[0].GetStructValue()
-	if got, want := first.GetFields()["identifier"].GetStringValue(), "urn:ai:agntcy.org:cid:"+testCID+":a2a"; got != want {
+	if got, want := first.GetFields()["identifier"].GetStringValue(), testBaseURN+":a2a"; got != want {
 		t.Errorf("first nested identifier = %q, want %q", got, want)
 	}
 
@@ -251,7 +254,7 @@ func TestRecordToCatalog_MultiModuleContainer(t *testing.T) {
 	}
 
 	second := entries.GetValues()[1].GetStructValue()
-	if got, want := second.GetFields()["identifier"].GetStringValue(), "urn:ai:agntcy.org:cid:"+testCID+":mcp"; got != want {
+	if got, want := second.GetFields()["identifier"].GetStringValue(), testBaseURN+":mcp"; got != want {
 		t.Errorf("second nested identifier = %q, want %q", got, want)
 	}
 }

--- a/proto/agntcy/oasfsdk/translation/v1/translation_service.proto
+++ b/proto/agntcy/oasfsdk/translation/v1/translation_service.proto
@@ -29,6 +29,9 @@ service TranslationService {
 
   // RecordToSkillMarkdown generates a SKILL.md file content from a Record.
   rpc RecordToSkillMarkdown(RecordToSkillMarkdownRequest) returns (RecordToSkillMarkdownResponse);
+
+  // RecordToCatalog generates an AI Catalog entry from a Record.
+  rpc RecordToCatalog(RecordToCatalogRequest) returns (RecordToCatalogResponse);
 }
 
 message RecordToGHCopilotRequest {
@@ -99,4 +102,27 @@ message RecordToSkillMarkdownRequest {
 message RecordToSkillMarkdownResponse {
   // The generated SKILL.md content as a plain string.
   string data = 1;
+}
+
+message RecordToCatalogRequest {
+  // The Record object to be converted into an AI Catalog entry.
+  google.protobuf.Struct record = 1;
+
+  // The content identifier (CID) embedded in the entry URN
+  // ("urn:ai:<host>:cid:<cid>"). Required: the raw OASF record does not
+  // carry its own CID, so the caller MUST supply one.
+  string cid = 2;
+
+  // Optional authority segment of the entry URN. Defaults to "agntcy.org"
+  // when empty.
+  string host = 3;
+
+  // Optional AI Catalog spec version embedded in the nested catalog of a
+  // multi-module (container) record. Defaults to "1.0" when empty.
+  string spec_version = 4;
+}
+
+message RecordToCatalogResponse {
+  // The generated AI Catalog entry in a structured format.
+  google.protobuf.Struct data = 1;
 }

--- a/proto/agntcy/oasfsdk/translation/v1/translation_service.proto
+++ b/proto/agntcy/oasfsdk/translation/v1/translation_service.proto
@@ -113,7 +113,7 @@ message RecordToCatalogRequest {
   // carry its own CID, so the caller MUST supply one.
   string cid = 2;
 
-  // Optional authority segment of the entry URN. Defaults to "agntcy.org"
+  // Optional authority segment of the entry URN. Defaults to "org.agntcy"
   // when empty.
   string host = 3;
 

--- a/server/controller/translation/v1/translation.go
+++ b/server/controller/translation/v1/translation.go
@@ -105,3 +105,7 @@ func (t *translationCtrl) RecordToSkillMarkdown(_ context.Context, req *translat
 
 	return &translationv1.RecordToSkillMarkdownResponse{Data: result}, nil
 }
+
+// TODO(catalog-grpc): add a RecordToCatalog handler here once the proto
+// bindings are generated and published to the BSR (after this PR merges) and
+// server/go.mod is bumped to the new buf.build/gen module version.


### PR DESCRIPTION
Adds an OASF-record to AI Catalog projection alongside the existing A2A, MCP, and agentskills translators, so consumers can render records into the `application/ai-catalog+json` shape without bespoke logic. The mapping is a pure `*structpb.Struct` transform: trust/identity metadata and publisher/host data beyond the URN host are intentionally left to the caller.

- Adds `RecordToCatalog(record, ...CatalogOption)`: emits a leaf entry for a single known module (media type + inline `data` from the module), and a container entry (`application/ai-catalog+json`) embedding a nested `AICatalog` with one entry per module for multi-module records.
- Adds the module→media-type/URN registry and constants (`MCPCatalogMediaType`, `A2ACatalogMediaType`, `AgentSkillsCatalogMediaType`, `CatalogContainerMediaType`, `DefaultCatalogURNHost`, `DefaultCatalogSpecVersion`).
- Adds `CatalogOption`s — `WithCatalogHost`, `WithCatalogCID` (required; errors when absent or blank), and `WithCatalogSpecVersion` — building `urn:ai:<host>:cid:<cid>[:<suffix>]` identifiers, with per-module suffixes to keep nested entries unique.
- Synthesizes `tags` from record skills, domains (preserving record order), and annotations (key-sorted for deterministic output); always carries module content inline via `data`.
- Adds `catalog_test.go` covering MCP/A2A/skill leaves, the multi-module container, missing-CID and nil-record errors, host override, and annotation tags.

Closes https://github.com/agntcy/dir/issues/1572