### PR TITLE
fix(translator): use camelCase in nested entries

### DIFF
--- a/pkg/translator/catalog.go
+++ b/pkg/translator/catalog.go
@@ -158,20 +158,24 @@ func RecordToCatalog(record *structpb.Struct, opts ...CatalogOption) (*structpb.
 	}
 
 	// 2+ known modules — container whose data is a nested AI Catalog.
+	// Keys inside the nested catalog use camelCase because the data field
+	// is a google.protobuf.Value whose struct keys are serialized verbatim
+	// (the gateway's proto→JSON camelCase conversion only applies to known
+	// proto field names, not to opaque Value structs).
 	nested := make([]*structpb.Value, 0, len(modules))
 
 	for _, m := range modules {
 		moduleURN := catalogURN(options.host, cid, catalogModules[m.name].URNSuffix)
 
-		entry := moduleToCatalogEntry(m, moduleURN)
-		entry.Fields["display_name"] = catalogStringValue(moduleDisplayName(m, name))
+		entry := nestedCatalogEntry(m, moduleURN)
+		entry.Fields["displayName"] = catalogStringValue(moduleDisplayName(m, name))
 
 		nested = append(nested, structpb.NewStructValue(entry))
 	}
 
 	nestedCatalog := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"spec_version": catalogStringValue(options.specVersion),
+			"specVersion": catalogStringValue(options.specVersion),
 			"entries": {
 				Kind: &structpb.Value_ListValue{ListValue: &structpb.ListValue{Values: nested}},
 			},
@@ -210,6 +214,26 @@ func moduleToCatalogEntry(m catalogModule, identifier string) *structpb.Struct {
 		Fields: map[string]*structpb.Value{
 			"identifier": catalogStringValue(identifier),
 			"media_type": catalogStringValue(proj.MediaType),
+			"data":       structpb.NewStructValue(data),
+		},
+	}
+}
+
+// nestedCatalogEntry builds a catalog entry for a module inside a
+// multi-module container's data field. Keys use camelCase because the
+// container data is a google.protobuf.Value serialized verbatim.
+func nestedCatalogEntry(m catalogModule, identifier string) *structpb.Struct {
+	proj := catalogModules[m.name]
+
+	data := m.data
+	if data == nil {
+		data = &structpb.Struct{Fields: map[string]*structpb.Value{}}
+	}
+
+	return &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"identifier": catalogStringValue(identifier),
+			"mediaType":  catalogStringValue(proj.MediaType),
 			"data":       structpb.NewStructValue(data),
 		},
 	}

--- a/pkg/translator/catalog_test.go
+++ b/pkg/translator/catalog_test.go
@@ -225,8 +225,8 @@ func TestRecordToCatalog_MultiModuleContainer(t *testing.T) {
 		t.Fatal("expected nested catalog data")
 	}
 
-	if got := nestedCatalog.GetFields()["spec_version"].GetStringValue(); got != translator.DefaultCatalogSpecVersion {
-		t.Errorf("spec_version = %q, want %q", got, translator.DefaultCatalogSpecVersion)
+	if got := nestedCatalog.GetFields()["specVersion"].GetStringValue(); got != translator.DefaultCatalogSpecVersion {
+		t.Errorf("specVersion = %q, want %q", got, translator.DefaultCatalogSpecVersion)
 	}
 
 	entries := nestedCatalog.GetFields()["entries"].GetListValue()
@@ -235,17 +235,19 @@ func TestRecordToCatalog_MultiModuleContainer(t *testing.T) {
 	}
 
 	// Modules are sorted by name: "integration/a2a" < "integration/mcp".
+	// Nested entries use camelCase keys since they live inside a
+	// google.protobuf.Value that is serialized verbatim.
 	first := entries.GetValues()[0].GetStructValue()
 	if got, want := first.GetFields()["identifier"].GetStringValue(), testBaseURN+":a2a"; got != want {
 		t.Errorf("first nested identifier = %q, want %q", got, want)
 	}
 
-	if got := first.GetFields()["display_name"].GetStringValue(); got != "multi-agent (A2A)" {
-		t.Errorf("first nested display_name = %q, want %q", got, "multi-agent (A2A)")
+	if got := first.GetFields()["displayName"].GetStringValue(); got != "multi-agent (A2A)" {
+		t.Errorf("first nested displayName = %q, want %q", got, "multi-agent (A2A)")
 	}
 
-	if got := first.GetFields()["media_type"].GetStringValue(); got != translator.A2ACatalogMediaType {
-		t.Errorf("first nested media_type = %q", got)
+	if got := first.GetFields()["mediaType"].GetStringValue(); got != translator.A2ACatalogMediaType {
+		t.Errorf("first nested mediaType = %q", got)
 	}
 
 	// Nested entries deliberately carry no tags.


### PR DESCRIPTION
In case of multiple modules in a record, an entry with nested entries is created, but wasn't ensured they also use camelCase for the JSON keys as per the current version of the AI Catalog specification.