### PR TITLE
ci: replace taskfile installation with offical action

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,9 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Taskfile
-        shell: bash
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Install Task
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Run End-to-End tests
         run: |

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -18,9 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Taskfile
-        shell: bash
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Install Task
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Setup license cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,9 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Taskfile
-        shell: bash
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Install Task
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Lint with golangci-lint
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Taskfile
-        shell: bash
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Install Task
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Build
         run: |
@@ -70,9 +69,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Taskfile
-        shell: bash
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Install Task
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -89,7 +87,6 @@ jobs:
 
       - name: Push Helm chart to GHCR
         run: task helm:push VERSION="${{ github.ref_name }}"
-
 
   release:
     name: Release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,9 +33,8 @@ jobs:
             server/go.sum
             pkg/go.sum
 
-      - name: Setup Taskfile
-        shell: bash
-        run: sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
+      - name: Install Task
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
 
       - name: Run unit tests with coverage
         run: |


### PR DESCRIPTION
Taskfile now have official action which provides better caching and versioning:
https://taskfile.dev/docs/installation#github-actions