### PR TITLE
feat(server): add grpc health service and gate e2e on real readiness

### DIFF
--- a/e2e/Taskfile.yaml
+++ b/e2e/Taskfile.yaml
@@ -29,8 +29,13 @@ tasks:
       - "{{.KIND_BIN}} load docker-image oasf-sdk:latest --name {{.CLUSTER_NAME}}"
       - echo "Installing Helm chart with local image..."
       - "{{.HELM_BIN}} install oasf-sdk ../helm/oasf-sdk --set image.repository=oasf-sdk --set image.tag=latest --set image.pullPolicy=Never"
+      # The chart defines a readiness probe against the server's gRPC health
+      # service (grpc.health.v1.Health), so this rollout gate waits until the
+      # server actually accepts RPCs — not just until the container starts. The
+      # timeout is raised accordingly: probes start after pod start and run
+      # every 5s.
       - echo "Waiting for deployment to be ready..."
-      - "{{.KUBECTL_BIN}} rollout status deployment/oasf-sdk --timeout=20s"
+      - "{{.KUBECTL_BIN}} rollout status deployment/oasf-sdk --timeout=60s"
 
   e2e:tear-down:
     desc: Tear down the e2e kind cluster

--- a/e2e/health_test.go
+++ b/e2e/health_test.go
@@ -1,0 +1,42 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+var _ = Describe("Health Service E2E", func() {
+	conn, err := grpc.NewClient(fmt.Sprintf("%s:%s", "0.0.0.0", "31234"), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	Expect(err).NotTo(HaveOccurred())
+
+	client := healthpb.NewHealthClient(conn)
+
+	Context("grpc.health.v1.Health", func() {
+		It("should report SERVING for the whole server", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			resp, err := client.Check(ctx, &healthpb.HealthCheckRequest{})
+			Expect(err).NotTo(HaveOccurred(), "health Check should not fail")
+			Expect(resp.GetStatus()).To(Equal(healthpb.HealthCheckResponse_SERVING), "server should report SERVING")
+		})
+
+		It("should return NOT_FOUND for an unknown service name", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			_, err := client.Check(ctx, &healthpb.HealthCheckRequest{Service: "does.not.Exist"})
+			Expect(err).To(HaveOccurred(), "unknown service should not be registered with the health service")
+		})
+	})
+})

--- a/helm/oasf-sdk/templates/deployment.yaml
+++ b/helm/oasf-sdk/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
-          {{- if .Values.readinessProbe }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            httpGet:
-              scheme: HTTP
-              path: /healthz
+            grpc:
               port: {{ .Values.service.internalPort }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/helm/oasf-sdk/values.yaml
+++ b/helm/oasf-sdk/values.yaml
@@ -42,6 +42,20 @@ ingress:
   # -- Ingress api domain name
   apiDomainName: dev.agntcy.org
 
+# Readiness probe against the server's standard gRPC health service
+# (grpc.health.v1.Health). Requires Kubernetes >= 1.24 for native gRPC probes.
+readinessProbe:
+  # -- Enable the gRPC readiness probe
+  enabled: true
+  # -- Number of consecutive probe failures before the pod is marked unready
+  failureThreshold: 3
+  # -- Seconds between probes
+  periodSeconds: 5
+  # -- Number of consecutive probe successes before the pod is marked ready
+  successThreshold: 1
+  # -- Per-probe timeout in seconds
+  timeoutSeconds: 2
+
 # -- Custom environment variables available to the deployment
 env: {}
 

--- a/server/server.go
+++ b/server/server.go
@@ -25,12 +25,15 @@ import (
 	translationcontrollerv1 "github.com/agntcy/oasf-sdk/server/controller/translation/v1"
 	validationcontrollerv1 "github.com/agntcy/oasf-sdk/server/controller/validation/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
 
 type Server struct {
-	cfg        *config.Config
-	grpcServer *grpc.Server
+	cfg          *config.Config
+	grpcServer   *grpc.Server
+	healthServer *health.Server
 }
 
 func Run(ctx context.Context, cfg *config.Config) error {
@@ -59,9 +62,17 @@ func NewServer(ctx context.Context, cfg *config.Config) (*Server, error) {
 	slog.Info("Creating new server", "config", cfg)
 
 	server := &Server{
-		cfg:        cfg,
-		grpcServer: grpc.NewServer(),
+		cfg:          cfg,
+		grpcServer:   grpc.NewServer(),
+		healthServer: health.NewServer(),
 	}
+
+	// Standard gRPC health service (grpc.health.v1.Health). The empty service
+	// name covers the whole server; it is flipped to SERVING once the listener
+	// is up (start) and back to NOT_SERVING on shutdown (close), so Kubernetes
+	// gRPC probes and grpc_health_probe report readiness accurately.
+	healthpb.RegisterHealthServer(server.grpcServer, server.healthServer)
+	server.healthServer.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
 
 	validationController, err := validationcontrollerv1.New()
 	if err != nil {
@@ -131,6 +142,9 @@ func extractorOptions(cfg *config.Config) []extractor.Option {
 }
 
 func (s Server) close() {
+	// Flip health to NOT_SERVING before stopping so probes and load balancers
+	// stop routing new work during the graceful drain.
+	s.healthServer.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
 	s.grpcServer.GracefulStop()
 }
 
@@ -149,6 +163,8 @@ func (s Server) start(ctx context.Context) error {
 			slog.Error("Server stopped unexpectedly", "error", err)
 		}
 	}()
+
+	s.healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 
 	return nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/agntcy/oasf-sdk/server/config"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // TestExtractorOptions checks how ExtractorConfig maps to extractor options by
@@ -49,5 +50,47 @@ func TestNewServerWithoutExtractor(t *testing.T) {
 
 	if srv == nil || srv.grpcServer == nil {
 		t.Fatal("expected a server with an initialized gRPC server")
+	}
+}
+
+// healthStatus queries the in-process health service for the whole-server
+// ("" service) status.
+func healthStatus(t *testing.T, srv *Server) healthpb.HealthCheckResponse_ServingStatus {
+	t.Helper()
+
+	resp, err := srv.healthServer.Check(context.Background(), &healthpb.HealthCheckRequest{})
+	if err != nil {
+		t.Fatalf("health Check: %v", err)
+	}
+
+	return resp.GetStatus()
+}
+
+// TestHealthLifecycle verifies the grpc.health.v1 status transitions:
+// NOT_SERVING after construction, SERVING once the listener is up, and
+// NOT_SERVING again after shutdown.
+func TestHealthLifecycle(t *testing.T) {
+	// Port 0 lets the OS pick a free port so the test cannot collide.
+	srv, err := NewServer(context.Background(), &config.Config{ListenAddress: "127.0.0.1:0"})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	if got := healthStatus(t, srv); got != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Fatalf("status before start = %v, want NOT_SERVING", got)
+	}
+
+	if err := srv.start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	if got := healthStatus(t, srv); got != healthpb.HealthCheckResponse_SERVING {
+		t.Fatalf("status after start = %v, want SERVING", got)
+	}
+
+	srv.close()
+
+	if got := healthStatus(t, srv); got != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Fatalf("status after close = %v, want NOT_SERVING", got)
 	}
 }


### PR DESCRIPTION
## Summary

Implements #63: adds a healthcheck capability to the server and makes the e2e
setup wait on real server readiness.

The literal `sleep 20` referenced in the issue was replaced by
`kubectl rollout status --timeout=20s` in #159, but that gate could not work
as intended: `values.yaml` defined no `readinessProbe` (so the deployment
template's probe block never rendered), and the template pointed at an HTTP
`/healthz` path the gRPC server never served. Rollout status therefore only
waited for the container to start, not for the server to accept RPCs.

## Changes

- **server:** register the standard `grpc.health.v1.Health` service
  (`google.golang.org/grpc/health`, per the grpc-go health example linked in
  the issue). Whole-server status starts NOT_SERVING, flips to SERVING once
  the listener is up, and back to NOT_SERVING before GracefulStop so probes
  stop routing new work during drain. No new module dependencies.
- **helm:** the readiness probe is now a native Kubernetes gRPC probe against
  the service port, enabled by default in `values.yaml` (k8s >= 1.24; the e2e
  kind cluster qualifies). The previous httpGet `/healthz` template block was
  dead config.
- **e2e:** `rollout status` now gates on actual gRPC readiness; the timeout is
  raised to 60s to leave room for probe periods. A new ginkgo spec asserts the
  health endpoint reports SERVING and rejects unknown service names.

## Testing

- Unit: `TestHealthLifecycle` covers the NOT_SERVING → SERVING → NOT_SERVING
  transitions across construction, start, and close.
- e2e: new `health_test.go` spec runs against the kind deployment alongside
  the existing decoding/translation/validation suites.
- `go build ./... && go vet ./... && go test ./...` pass in the server module;
  the e2e module compiles and vets cleanly (specs need the kind cluster).

Fixes #63

## Diff stat

 e2e/Taskfile.yaml                       |  7 +++++-
 e2e/health_test.go                      | 43 ++++++++++++++++++++++++++++++
 helm/oasf-sdk/templates/deployment.yaml |  6 ++---
 helm/oasf-sdk/values.yaml               | 14 ++++++++++
 server/server.go                        | 24 +++++++++++++++---
 server/server_test.go                   | 43 +++++++++++++++++++++++++++++++++
 6 files changed, 127 insertions(+), 9 deletions(-)

## Verification output

server module:  go build OK, go vet OK
                ok  github.com/agntcy/oasf-sdk/server                 1.701s
                ok  github.com/agntcy/oasf-sdk/server/config          0.635s
                (+ controller pkgs ok)
                TestHealthLifecycle: --- PASS (0.00s)
e2e module:     go vet OK; test binary compiles (`go test -run NONE` ok —
                actual specs need the kind cluster, exercised by the e2e
                GitHub workflow on PR)
helm/Taskfile:  values.yaml and e2e/Taskfile.yaml re-parsed with PyYAML —
                readinessProbe block and 60s rollout cmd verified.
                (helm binary not available locally; template change mirrors
                the existing conditional block structure — CI e2e run is the
                real gate since it installs the chart on kind)
gofmt:          clean on server.go / server_test.go / health_test.go
                (CRLF checkout artifacts verified clean via `git show :file`)
go.mod/go.sum:  unchanged (health pkg ships in the grpc module)

## Submission prerequisite

No fork of `agntcy/oasf-sdk` exists under `conorbronsdon` yet. At submission time: `gh repo fork agntcy/oasf-sdk --clone=false`, add fork remote, push branch, open draft PR.

## DCO

Commit `938962d` is signed off (`git commit -s`):
`Signed-off-by: Conor Bronsdon <120674402+conorbronsdon@users.noreply.github.com>`
`Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
