### PR TITLE
fix(helm): render nodePort only for NodePort and LoadBalancer services

### DIFF
--- a/e2e/Taskfile.yaml
+++ b/e2e/Taskfile.yaml
@@ -28,7 +28,9 @@ tasks:
       - echo "Loading Docker image into Kind cluster..."
       - "{{.KIND_BIN}} load docker-image oasf-sdk:latest --name {{.CLUSTER_NAME}}"
       - echo "Installing Helm chart with local image..."
-      - "{{.HELM_BIN}} install oasf-sdk ../helm/oasf-sdk --set image.repository=oasf-sdk --set image.tag=latest --set image.pullPolicy=Never"
+      # The chart defaults to ClusterIP; the tests dial the server through the
+      # kind hostPort mapping in kind-config.yaml, which needs a NodePort.
+      - "{{.HELM_BIN}} install oasf-sdk ../helm/oasf-sdk --set image.repository=oasf-sdk --set image.tag=latest --set image.pullPolicy=Never --set service.type=NodePort"
       # The chart defines a readiness probe against the server's gRPC health
       # service (grpc.health.v1.Health), so this rollout gate waits until the
       # server actually accepts RPCs — not just until the container starts. The

--- a/helm/oasf-sdk/templates/service.yaml
+++ b/helm/oasf-sdk/templates/service.yaml
@@ -17,7 +17,9 @@ spec:
   ports:
     - port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
+      {{- if and .Values.service.nodePort (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) }}
       nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
       protocol: TCP
       name: {{ .Values.service.name }}
   selector:

--- a/helm/oasf-sdk/values.yaml
+++ b/helm/oasf-sdk/values.yaml
@@ -14,13 +14,15 @@ image:
 service:
   # -- Service name
   name: oasf-sdk
-  # -- Service type
-  type: NodePort
+  # -- Service type. The gRPC server has no TLS or authentication, so the
+  # default keeps it reachable only from inside the cluster. Set to `NodePort`
+  # or `LoadBalancer` to expose it externally.
+  type: ClusterIP
   # -- Service external port
   externalPort: 31234
   # -- Service internal port
   internalPort: 31234
-  # -- Service node port
+  # -- Service node port. Only rendered when `service.type` is `NodePort` or `LoadBalancer`.
   nodePort: 31234
   # -- Service annotations, e.g. if type is AWS LoadBalancer and you want to add security groups
   annotations: {}


### PR DESCRIPTION
## Summary

Closes #179.

The chart could not deploy the server as a cluster-internal service: `templates/service.yaml` rendered `nodePort` unconditionally, and Kubernetes rejects `nodePort` on a `ClusterIP` service. Consumers were therefore forced onto `NodePort`, which publishes the gRPC server — which has no TLS and no authentication — on every node's IP at `:31234`.

That matters for [agntcy/dir](https://github.com/agntcy/dir), where the API gateway is gaining an optional OASF-SDK dependency and dials the server over plaintext gRPC. Plaintext is defensible for a cluster-internal hop on the pod network; it is not defensible when the same unauthenticated endpoint is reachable from outside the cluster.

## Changes

- **helm/oasf-sdk/templates/service.yaml** — render `nodePort` only when it is set *and* `service.type` is `NodePort` or `LoadBalancer`. This is the blocking fix and is backward compatible on its own.
- **helm/oasf-sdk/values.yaml** — default `service.type` to `ClusterIP`, leaving external exposure opt-in. The comment records why (no TLS/auth on the server), and the `nodePort` comment notes when it applies.
- **e2e/Taskfile.yaml** — pass `--set service.type=NodePort` on the e2e `helm install`. The suite was silently relying on the old default: the tests dial `localhost:31234` through the kind `hostPort` mapping in `kind-config.yaml`, which needs a NodePort.

## Testing

`helm template` against the chart, covering each acceptance criterion:

| Case | Result |
| --- | --- |
| `--set service.type=ClusterIP` | valid Service, no `nodePort` |
| default (no flags) | `type: ClusterIP`, no `nodePort` |
| `--set service.type=NodePort` | `nodePort: 31234`, unchanged from before |
| `--set service.type=LoadBalancer` | `nodePort: 31234` |
| `--set service.type=NodePort --set service.nodePort=null` | omitted, so Kubernetes auto-assigns |

Full local run:

- `task helm:lint` — 1 chart linted, 0 failed
- `task lint` — buf and golangci-lint clean across `server`, `e2e`, `pkg` (0 issues)
- `task test:e2e` — 42/42 specs pass against a real kind cluster, exercising the updated install command
- `task test:unit` — pass

## Upgrade note

Item 1 alone is backward compatible; item 2 changes a default, so an existing deployment that relied on the chart's `NodePort` default now needs `--set service.type=NodePort` explicitly. Worth calling out in the release notes for the next minor.
